### PR TITLE
Feature: Input parameters and nested tasks

### DIFF
--- a/.github/workflows/_build.py
+++ b/.github/workflows/_build.py
@@ -1,0 +1,31 @@
+from portray import config
+import yaml
+
+# Note that this does not work for reloads.
+mkdocs = config.mkdocs
+def _mkdocs(directory: str, **overrides) -> dict:
+    superfences = yaml.unsafe_load("""
+      preserve_tabs: true
+      custom_fences:
+        # Mermaid diagrams
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+    """)
+    print(overrides)
+    overrides.setdefault("markdown_extensions", [])
+    for n, ext in enumerate(overrides["markdown_extensions"]):
+        if ext == "pymdownx.superfences":
+            ext = {"pymdownx.superfences": {}}
+        elif isinstance(ext, dict) and len(ext) == 1 and "pymdownx.superfences" in ext:
+            ...
+        else:
+            continue
+        ext["pymdownx.superfences"].update(superfences)
+        overrides["markdown_extensions"][n] = ext
+        print(overrides)
+    res = mkdocs(directory, **overrides)
+    return res
+config.mkdocs = _mkdocs
+
+from portray import __main__

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,4 +11,4 @@ jobs:
       - name: install
         run: python -m pip install .
       - name: portray
-        run: pip install portray; python -m portray on_github_pages -f
+        run: pip install portray pyyaml; python .github/workflows/_build.py on_github_pages -f

--- a/.github/workflows/python-static-ci.yml
+++ b/.github/workflows/python-static-ci.yml
@@ -23,3 +23,5 @@ jobs:
       - name: install
         run: python -m pip install .
       - uses: pypa/gh-action-pip-audit@v1.0.8
+        with:
+          paths: "./src ./tests"

--- a/.github/workflows/python-test-ci.yml
+++ b/.github/workflows/python-test-ci.yml
@@ -17,8 +17,11 @@ jobs:
       run: |
         pip install pytest pytest-cov
         pip install --no-build-isolation --no-deps --disable-pip-version-check -e .
-        python -m pytest --doctest-modules
+        python -m pytest --doctest-modules --ignore=example
         python -m doctest -v docs/*.md
+    # name: Test examples
+    # run: |
+    #   (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
   unit-conda:
     runs-on: ubuntu-latest
     steps:
@@ -39,4 +42,8 @@ jobs:
         conda install -c /tmp/output/noarch/*.conda --update-deps --use-local dewret
         conda install pytest
         $CONDA/bin/pytest
+        python -m pytest --doctest-modules --ignore=example
         python -m doctest -v docs/*.md
+    # name: Test examples
+    # run: |
+    #   (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,6 +32,8 @@ steps:
     in:
       num:
         default: 3
+    out:
+    - out
     run: increment
 ```
 
@@ -62,6 +64,8 @@ steps:
     in:
       num:
         default: 3
+    out:
+    - out
     run: increment
 
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,6 +27,10 @@ $ python -m dewret --pretty workflow.py increment num:3
 ```yaml
 class: Workflow
 cwlVersion: 1.2
+outputs:
+  out:
+    outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out
+    type: string
 steps:
   increment-012ef3b3ffb9d15c3f2837aa4bb20a8d:
     in:
@@ -59,6 +63,10 @@ and backends, as well as bespoke serialization or formatting.
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
+outputs:
+  out:
+    outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out
+    type: string
 steps:
   increment-012ef3b3ffb9d15c3f2837aa4bb20a8d:
     in:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,6 +63,7 @@ and backends, as well as bespoke serialization or formatting.
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
+inputs: {}
 outputs:
   out:
     outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ cwlVersion: 1.2
 outputs:
   out:
     outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out
-    type: string
+    type: int
 steps:
   increment-012ef3b3ffb9d15c3f2837aa4bb20a8d:
     in:
@@ -54,7 +54,7 @@ and backends, as well as bespoke serialization or formatting.
 >>> from dewret.renderers.cwl import render
 >>> 
 >>> @task()
-... def increment(num: int):
+... def increment(num: int) -> int:
 ...     return num + 1
 >>>
 >>> result = increment(num=3)
@@ -67,7 +67,7 @@ inputs: {}
 outputs:
   out:
     outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out
-    type: string
+    type: int
 steps:
   increment-012ef3b3ffb9d15c3f2837aa4bb20a8d:
     in:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -145,6 +145,14 @@ you can use nested tasks. These are run at _render_ time, not
 execution time. In other words, they do not appear in the
 final graph, and so must only combine other tasks.
 
+Note that, as with all dewret calculations, only the steps
+necessary to achieve the ultimate output are included in the final
+graph. Therefore, nested tasks must return a step execution
+(task that is being called) that forces any other calculations
+you wish to happen. __In other words, if an task in a
+nested task does not have an impact on the return value,
+it will disappear__.
+
 For example:
 ```python
 >>> from dewret.tasks import nested_task

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,5 +1,15 @@
 # Workflows
 
+## Setup
+
+We can pull in dewret tools to produce CWL with a small number of imports.
+
+```python
+>>> import sys
+>>> import yaml
+>>> from dewret.tasks import task, run
+>>> from dewret.renderers.cwl import render
+
 ## Dependencies
 
 Specifying step interdependencies is possible by combining lazy-evaluated function
@@ -18,11 +28,6 @@ graph TD
 In code, this would be:
 
 ```python
->>> import sys
->>> import yaml
->>> from dewret.tasks import task, run
->>> from dewret.renderers.cwl import render
->>> 
 >>> @task()
 ... def increment(num: int) -> int:
 ...     """Increment an integer."""
@@ -52,6 +57,7 @@ In code, this would be:
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
+inputs: {}
 outputs:
   out:
     outputSource: sum-1/out
@@ -87,5 +93,98 @@ steps:
     out:
     - out
     run: sum
+
+```
+
+## Parameters
+
+The tool will spot global variables that you have used when building your tasks,
+and treat them as parameters. It will try to get the type from the typehint, or
+the value that you have set it to. This only works for basic types (and dict/lists of
+those).
+
+For example:
+```python
+>>> INPUT_NUM = 3
+>>> @task()
+... def rotate(num: int) -> int:
+...    """Rotate an integer."""
+...    return (num + INPUT_NUM) % INPUT_NUM
+>>>
+>>> result = rotate(num=3)
+>>> workflow = run(result, simplify_ids=True)
+>>> cwl = render(workflow)
+>>> yaml.dump(cwl, sys.stdout, indent=2)
+class: Workflow
+cwlVersion: 1.2
+inputs:
+  INPUT_NUM:
+    label: INPUT_NUM
+    type: int
+outputs:
+  out:
+    outputSource: rotate-1/out
+    type: string
+steps:
+  rotate-1:
+    in:
+      INPUT_NUM:
+        source: INPUT_NUM
+      num:
+        default: 3
+    out:
+    - out
+    run: rotate
+
+```
+
+## Nested tasks
+
+When you wish to combine tasks together programmatically,
+you can use nested tasks. These are run at _render_ time, not
+execution time. In other words, they do not appear in the
+final graph, and so must only combine other tasks.
+
+For example:
+```python
+>>> from dewret.tasks import nested_task
+>>> @nested_task()
+... def double_rotate(num: int) -> int:
+...    """Rotate an integer twice."""
+...    return rotate(num=rotate(num=num))
+>>>
+>>> result = double_rotate(num=3)
+>>> workflow = run(result, simplify_ids=True)
+>>> cwl = render(workflow)
+>>> yaml.dump(cwl, sys.stdout, indent=2)
+class: Workflow
+cwlVersion: 1.2
+inputs:
+  INPUT_NUM:
+    label: INPUT_NUM
+    type: int
+outputs:
+  out:
+    outputSource: rotate-2/out
+    type: string
+steps:
+  rotate-1:
+    in:
+      INPUT_NUM:
+        source: INPUT_NUM
+      num:
+        default: 3
+    out:
+    - out
+    run: rotate
+  rotate-2:
+    in:
+      INPUT_NUM:
+        source: INPUT_NUM
+      num:
+        source: rotate-1/out
+    out:
+    - out
+    run: rotate
 
 ```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -9,6 +9,7 @@ We can pull in dewret tools to produce CWL with a small number of imports.
 >>> import yaml
 >>> from dewret.tasks import task, run
 >>> from dewret.renderers.cwl import render
+
 ```
 
 ## Dependencies
@@ -62,7 +63,7 @@ inputs: {}
 outputs:
   out:
     outputSource: sum-1/out
-    type: string
+    type: int
 steps:
   double-1:
     in:
@@ -125,7 +126,7 @@ inputs:
 outputs:
   out:
     outputSource: rotate-1/out
-    type: string
+    type: int
 steps:
   rotate-1:
     in:
@@ -175,7 +176,7 @@ inputs:
 outputs:
   out:
     outputSource: rotate-2/out
-    type: string
+    type: int
 steps:
   rotate-1:
     in:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -52,6 +52,10 @@ In code, this would be:
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
+outputs:
+  out:
+    outputSource: sum-1/out
+    type: string
 steps:
   double-1:
     in:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,11 @@
+# Workflows
+
+## Step Dependencies
+
+```diagram
+graph TD
+    A[Hard] -->|Text| B(Round)
+    B --> C{Decision}
+    C -->|One| D[Result 1]
+    C -->|Two| E[Result 2]
+```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -9,6 +9,7 @@ We can pull in dewret tools to produce CWL with a small number of imports.
 >>> import yaml
 >>> from dewret.tasks import task, run
 >>> from dewret.renderers.cwl import render
+```
 
 ## Dependencies
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,11 +1,87 @@
 # Workflows
 
-## Step Dependencies
+## Dependencies
 
-```diagram
+Specifying step interdependencies is possible by combining lazy-evaluated function
+calls.
+
+Dewret hashes the parameters to identify and unify steps. This lets you do, for example:
+
+```mermaid
 graph TD
-    A[Hard] -->|Text| B(Round)
-    B --> C{Decision}
-    C -->|One| D[Result 1]
-    C -->|Two| E[Result 2]
+    A[increment] --> B[double]
+    A[increment] --> C[mod10]
+    B[double] --> D[sum]
+    C[mod10] --> D[sum]
+```
+
+In code, this would be:
+
+```python
+>>> import sys
+>>> import yaml
+>>> from dewret.tasks import task, run
+>>> from dewret.renderers.cwl import render
+>>> 
+>>> @task()
+... def increment(num: int) -> int:
+...     """Increment an integer."""
+...     return num + 1
+>>> 
+>>> @task()
+... def double(num: int) -> int:
+...     """Double an integer."""
+...     return 2 * num
+>>> 
+>>> @task()
+... def mod10(num: int) -> int:
+...     """Double an integer."""
+...     return num % 10
+>>> 
+>>> @task()
+... def sum(left: int, right: int) -> int:
+...     """Add two integers."""
+...     return left + right
+>>>
+>>> result = sum(
+...     left=double(num=increment(num=23)),
+...     right=mod10(num=increment(num=23))
+... )
+>>> workflow = run(result, simplify_ids=True)
+>>> cwl = render(workflow)
+>>> yaml.dump(cwl, sys.stdout, indent=2)
+class: Workflow
+cwlVersion: 1.2
+steps:
+  double-1:
+    in:
+      num:
+        source: increment-1/out
+    out:
+    - out
+    run: double
+  increment-1:
+    in:
+      num:
+        default: 23
+    out:
+    - out
+    run: increment
+  mod10-1:
+    in:
+      num:
+        source: increment-1/out
+    out:
+    - out
+    run: mod10
+  sum-1:
+    in:
+      left:
+        source: double-1/out
+      right:
+        source: mod10-1/out
+    out:
+    - out
+    run: sum
+
 ```

--- a/example/extra.py
+++ b/example/extra.py
@@ -1,0 +1,33 @@
+"""Supporting procedures for complex workflow.
+
+Illustrates the ability to modularize code.
+"""
+
+from dewret.tasks import task
+
+JUMP: int = 10
+
+@task()
+def increase(num: int) -> int:
+    """Add 1 to a number."""
+    return num + JUMP
+
+@task()
+def increment(num: int) -> int:
+    """Increment an integer."""
+    return num + 1
+
+@task()
+def double(num: int) -> int:
+    """Double an integer."""
+    return 2 * num
+
+@task()
+def mod10(num: int) -> int:
+    """Double an integer."""
+    return num % 10
+
+@task()
+def sum(left: int, right: int) -> int:
+    """Add two integers."""
+    return left + right

--- a/example/workflow_complex.py
+++ b/example/workflow_complex.py
@@ -1,11 +1,15 @@
 """Complex workflow.
 
 Useful as an example of a simple workflow.
+
+```sh
+$ python -m dewret workflow_complex.py --pretty run
+```
 """
 
 from dewret.workflow import Lazy
 from dewret.tasks import nested_task
-from lib.extra import sum, double, increase
+from extra import sum, double, increase
 
 STARTING_NUMBER: int = 23
 

--- a/example/workflow_complex.py
+++ b/example/workflow_complex.py
@@ -1,0 +1,20 @@
+"""Complex workflow.
+
+Useful as an example of a simple workflow.
+"""
+
+from dewret.workflow import Lazy
+from dewret.tasks import nested_task
+from lib.extra import sum, double, increase
+
+STARTING_NUMBER: int = 23
+
+@nested_task()
+def run() -> int | float:
+    """Creates a graph of task calls."""
+    left = double(num=increase(num=STARTING_NUMBER))
+    right = increase(num=increase(num=17))
+    return sum(
+        left=left,
+        right=right
+    )

--- a/example/workflow_qs.py
+++ b/example/workflow_qs.py
@@ -1,6 +1,10 @@
 """Quickstart workflow.
 
 Useful as an example of a simple workflow.
+
+```sh
+$ python -m dewret workflow_qs.py --pretty increment num:3 --backend DASK
+```
 """
 
 from dewret.tasks import task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,16 @@ packages = ["src/dewret"]
 
 [tool.portray]
 modules = ["dewret"]
+config_file_path = "mkdocs.yml"
 extra_markdown_extensions = [
   "pymdownx.inlinehilite",
   "pymdownx.snippets",
-  "pymdownx.superfences",
   "pymdownx.highlight",
+]
+
+[tool.portray.mkdocs]
+markdown_extensions = [
+  { "pymdownx.superfences" = {} }
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,4 +44,4 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.11"
-dependencies = ["dask >= 2022", "pyyaml", "attrs", "click", "setuptools >= 65.5.1"]
+dependencies = ["dask >= 2022", "pyyaml", "attrs", "click", "setuptools >= 65.5.1", "numpy", "sympy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ packages = ["src/dewret"]
 
 [tool.portray]
 modules = ["dewret"]
-config_file_path = "mkdocs.yml"
 extra_markdown_extensions = [
   "pymdownx.inlinehilite",
   "pymdownx.snippets",

--- a/src/dewret/__main__.py
+++ b/src/dewret/__main__.py
@@ -43,6 +43,7 @@ def render(workflow_py: str, task: str, arguments: list[str], pretty: bool, back
     ARGUMENTS is zero or more pairs representing constant arguments to pass to the task, in the format `key:val` where val is a JSON basic type.
     """
     sys.path.append(str(Path(workflow_py).parent))
+    print(sys.path)
     loader = importlib.machinery.SourceFileLoader("workflow", workflow_py)
     workflow = loader.load_module()
     task_fn = getattr(workflow, task)

--- a/src/dewret/__main__.py
+++ b/src/dewret/__main__.py
@@ -20,13 +20,14 @@ this may be of use.
 """
 
 import importlib
+from pathlib import Path
 import yaml
 import sys
 import click
 import json
 
 from .renderers.cwl import render as cwl_render
-from .tasks import set_backend, Backend
+from .tasks import set_backend, Backend, run
 
 @click.command()
 @click.option("--pretty", is_flag=True, show_default=True, default=False, help="Pretty-print output where possible.")
@@ -41,6 +42,7 @@ def render(workflow_py: str, task: str, arguments: list[str], pretty: bool, back
     TASK is the name of (decorated) task in workflow module.
     ARGUMENTS is zero or more pairs representing constant arguments to pass to the task, in the format `key:val` where val is a JSON basic type.
     """
+    sys.path.append(str(Path(workflow_py).parent))
     loader = importlib.machinery.SourceFileLoader("workflow", workflow_py)
     workflow = loader.load_module()
     task_fn = getattr(workflow, task)
@@ -51,7 +53,7 @@ def render(workflow_py: str, task: str, arguments: list[str], pretty: bool, back
         key, val = arg.split(":", 1)
         kwargs[key] = json.loads(val)
 
-    cwl = cwl_render(task_fn(**kwargs))
+    cwl = cwl_render(run(task_fn(**kwargs), simplify_ids=True))
     if pretty:
         yaml.dump(cwl, sys.stdout, indent=2)
     else:

--- a/src/dewret/backends/_base.py
+++ b/src/dewret/backends/_base.py
@@ -17,7 +17,7 @@
 Definition of a protocol that valid backend modules must fulfil.
 """
 
-from typing import Protocol
+from typing import Protocol, Any
 from dewret.workflow import LazyFactory, Lazy, Workflow, StepReference
 
 class BackendModule(Protocol):
@@ -32,7 +32,7 @@ class BackendModule(Protocol):
     """
     lazy: LazyFactory
 
-    def run(self, workflow: Workflow, task: Lazy) -> StepReference:
+    def run(self, workflow: Workflow, task: Lazy) -> StepReference[Any]:
         """Execute a lazy task for this `Workflow`.
 
         Args:
@@ -41,5 +41,16 @@ class BackendModule(Protocol):
 
         Returns:
             Reference to the final output step.
+        """
+        ...
+
+    def is_lazy(self, lazy: Any) -> bool:
+        """Confirm whether this is a lazy-evaluatable function.
+
+        Args:
+            lazy: suspected lazy-evaluatable function to check.
+
+        Returns:
+            True if this is a lazy-evaluatable function for this backend, otherwise False.
         """
         ...

--- a/src/dewret/backends/_base.py
+++ b/src/dewret/backends/_base.py
@@ -18,7 +18,7 @@ Definition of a protocol that valid backend modules must fulfil.
 """
 
 from typing import Protocol, Any
-from dewret.workflow import LazyFactory, Lazy, Workflow, StepReference
+from dewret.workflow import LazyFactory, Lazy, Workflow, StepReference, Target
 
 class BackendModule(Protocol):
     """Requirements for a valid backend module.
@@ -41,6 +41,24 @@ class BackendModule(Protocol):
 
         Returns:
             Reference to the final output step.
+        """
+        ...
+
+    def unwrap(self, lazy: Lazy) -> Target:
+        """Unwraps a lazy-evaluated function to get the function.
+
+        Ideally, we could use the `__wrapped__` property but not all
+        workflow engines support this, and most importantly, dask has
+        only done so as of 2024.03.
+
+        Args:
+            lazy: task to be unwrapped.
+
+        Returns:
+            Original target.
+
+        Raises:
+            RuntimeError: if the task is not a wrapped function.
         """
         ...
 

--- a/src/dewret/backends/backend_dask.py
+++ b/src/dewret/backends/backend_dask.py
@@ -49,6 +49,14 @@ class Delayed(Protocol):
         ...
 
 def is_lazy(task: Any) -> bool:
+    """Checks if a task is really a lazy-evaluated function for this backend.
+
+    Args:
+        task: suspected lazy-evaluated function.
+
+    Returns:
+        True if so, False otherwise.
+    """
     return isinstance(task, Delayed)
 
 lazy = delayed
@@ -61,6 +69,7 @@ def run(workflow: Workflow | None, task: Lazy) -> StepReference[Any]:
         workflow: `Workflow` in which to record the execution.
         task: `dask.delayed` function, wrapped by dewret, that we wish to compute.
     """
-    if not isinstance(task, Delayed):
+    # We need isinstance to reassure type-checker.
+    if not isinstance(task, Delayed) or not is_lazy(task):
         raise RuntimeError("Cannot mix backends")
     return task.compute(__workflow__=workflow)

--- a/src/dewret/backends/backend_dask.py
+++ b/src/dewret/backends/backend_dask.py
@@ -19,7 +19,7 @@ Lazy-evaluation via `dask.delayed`.
 
 from dask.delayed import delayed
 from dewret.workflow import Workflow, Lazy, StepReference
-from typing import Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable, Any
 
 @runtime_checkable
 class Delayed(Protocol):
@@ -32,7 +32,7 @@ class Delayed(Protocol):
     More info: https://github.com/dask/dask/issues/7779
     """
 
-    def compute(self, __workflow__: Workflow | None) -> StepReference:
+    def compute(self, __workflow__: Workflow | None) -> StepReference[Any]:
         """Evaluate this `dask.delayed`.
 
         Evaluate a delayed (dask lazy-evaluated) function. dewret
@@ -48,8 +48,9 @@ class Delayed(Protocol):
         """
         ...
 
+is_lazy = lambda task: isinstance(task, Delayed)
 lazy = delayed
-def run(workflow: Workflow | None, task: Lazy) -> StepReference:
+def run(workflow: Workflow | None, task: Lazy) -> StepReference[Any]:
     """Execute a task as the output of a workflow.
 
     Runs a task with dask.
@@ -58,6 +59,6 @@ def run(workflow: Workflow | None, task: Lazy) -> StepReference:
         workflow: `Workflow` in which to record the execution.
         task: `dask.delayed` function, wrapped by dewret, that we wish to compute.
     """
-    if not isinstance(task, Delayed):
+    if not is_lazy(task):
         raise RuntimeError("Cannot mix backends")
     return task.compute(__workflow__=workflow)

--- a/src/dewret/backends/backend_dask.py
+++ b/src/dewret/backends/backend_dask.py
@@ -48,7 +48,9 @@ class Delayed(Protocol):
         """
         ...
 
-is_lazy = lambda task: isinstance(task, Delayed)
+def is_lazy(task: Any) -> bool:
+    return isinstance(task, Delayed)
+
 lazy = delayed
 def run(workflow: Workflow | None, task: Lazy) -> StepReference[Any]:
     """Execute a task as the output of a workflow.
@@ -59,6 +61,6 @@ def run(workflow: Workflow | None, task: Lazy) -> StepReference[Any]:
         workflow: `Workflow` in which to record the execution.
         task: `dask.delayed` function, wrapped by dewret, that we wish to compute.
     """
-    if not is_lazy(task):
+    if not isinstance(task, Delayed):
         raise RuntimeError("Cannot mix backends")
     return task.compute(__workflow__=workflow)

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -31,6 +31,7 @@ class ReferenceDefinition:
 
     Normally points to a value or a step.
     """
+    source: str
 
     @classmethod
     def from_reference(cls, ref: Reference) -> "ReferenceDefinition":
@@ -41,7 +42,7 @@ class ReferenceDefinition:
         Args:
             ref: reference to convert.
         """
-        return cls()
+        return cls(source=str(ref))
 
     def render(self) -> dict[str, RawType]:
         """Render to a dict-like structure.
@@ -50,7 +51,9 @@ class ReferenceDefinition:
             Reduced form as a native Python dict structure for
             serialization.
         """
-        raise NotImplementedError("Implement references")
+        return {
+            "source": self.source
+        }
 
 @define
 class StepDefinition:
@@ -105,7 +108,8 @@ class StepDefinition:
                     if isinstance(ref, ReferenceDefinition) else
                     {"default": ref.value}
                 ) for key, ref in self.in_.items()
-            }
+            },
+            "out": ["out"]
         }
 
 @define

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -20,8 +20,9 @@ current workflow.
 
 from attrs import define
 from collections.abc import Mapping
+from typing import TypedDict, NotRequired, get_args, Union, cast
 
-from dewret.workflow import Reference, Raw, Workflow, Step, Task, StepReference
+from dewret.workflow import Reference, Raw, Workflow, Step, Task, StepReference, Parameter
 from dewret.tasks import run
 from dewret.utils import RawType
 
@@ -89,7 +90,7 @@ class StepDefinition:
                     ReferenceDefinition.from_reference(param)
                     if isinstance(param, Reference) else
                     param
-                ) for key, param in step.parameters.items()
+                ) for key, param in step.arguments.items()
             }
         )
 
@@ -110,6 +111,145 @@ class StepDefinition:
                 ) for key, ref in self.in_.items()
             },
             "out": ["out"]
+        }
+
+def to_cwl_type(typ: type) -> str:
+    """Map Python types to CWL types.
+
+    Args:
+        typ: a Python basic type.
+
+    Returns:
+        CWL specification type name.
+    """
+    if typ == int:
+        return "int"
+    elif typ == bool:
+        return "boolean"
+    elif typ == dict:
+        return "record"
+    elif typ == list:
+        return "array"
+    elif typ == float:
+        return "double"
+    elif typ == str:
+        return "string"
+    else:
+        raise TypeError("Cannot render complex type to CWL")
+
+class CommandInputSchema(TypedDict):
+    """Structure for referring to a raw type in CWL.
+
+    Encompasses several CWL types. In future, it may be best to
+    use _cwltool_ or another library for these basic structures.
+
+    Attributes:
+        type: CWL type of this input.
+        label: name to show for this input.
+        fields: (for `record`) individual fields in a dict-like structure.
+        items: (for `array`) type that each field will have.
+    """
+    type: str
+    label: str
+    fields: NotRequired[dict[str, "CommandInputSchema"]]
+    items: NotRequired[Union[str, "CommandInputSchema"]]
+
+def raw_to_command_input_schema(label: str, value: RawType) -> CommandInputSchema | str:
+    """Infer the CWL input structure for this value.
+
+    Inspects the value, to work out an appropriate structure
+    describing it in CWL.
+
+    Args:
+        label: name of the variable.
+        value: basic-typed variable from which to build structure.
+
+    Returns:
+        Structure used to define (possibly compound) basic types for input.
+    """
+    if isinstance(value, dict) or isinstance(value, list):
+        return _raw_to_command_input_schema_internal(label, value)
+    else:
+        return to_cwl_type(type(value))
+
+def _raw_to_command_input_schema_internal(label: str, value: RawType) -> CommandInputSchema:
+    typ = to_cwl_type(type(value))
+    structure: CommandInputSchema = {"type": typ, "label": label}
+    if isinstance(value, dict):
+        structure["fields"] = {
+            key: _raw_to_command_input_schema_internal(key, val)
+            for key, val in value.items()
+        }
+    elif isinstance(value, list):
+        typeset = set(get_args(value))
+        if not typeset:
+            typeset = {type(item) for item in value}
+        if len(typeset) != 1:
+            raise RuntimeError(
+                "For CWL, an input array must have a consistent type, "
+                "and we need at least one element to infer it, or an explicit typehint."
+            )
+        structure["items"] = to_cwl_type(typeset.pop())
+    return structure
+
+@define
+class InputsDefinition:
+    """CWL-renderable representation of an input parameter block.
+
+    Turns dewret results into a CWL input block.
+
+    Attributes:
+        input: sequence of results from a workflow.
+    """
+
+    inputs: dict[str, "CommandInputParameter"]
+
+    @define
+    class CommandInputParameter:
+        """CWL-renderable reference to a specific input.
+
+        Attributes:
+            type: type of variable
+            name: fully-qualified name of the input.
+        """
+        type: str | CommandInputSchema
+        label: str
+
+    @classmethod
+    def from_parameters(cls, parameters: list[Parameter[RawType]]) -> "InputsDefinition":
+        """Takes a list of parameters into a CWL structure.
+
+        Uses the parameters to fill out the necessary input fields.
+
+        Returns:
+            CWL-like structure representing all workflow outputs.
+        """
+        return cls(
+            inputs={
+                input.__name__: cls.CommandInputParameter(
+                    label=input.__name__,
+                    type=raw_to_command_input_schema(
+                        label=input.__name__,
+                        value=input.__default__
+                    )
+                ) for input in parameters
+            }
+        )
+
+    def render(self) -> dict[str, RawType]:
+        """Render to a dict-like structure.
+
+        Returns:
+            Reduced form as a native Python dict structure for
+            serialization.
+        """
+        return {
+            key: {
+                # Would rather not cast, but CommandInputSchema is dict[RawType]
+                # by construction, where type is seen as a TypedDict subclass.
+                "type": cast(RawType, input.type),
+                "label": input.label
+            } for key, input in self.inputs.items()
         }
 
 @define
@@ -179,6 +319,7 @@ class WorkflowDefinition:
     """
 
     steps: list[StepDefinition]
+    inputs: InputsDefinition
     outputs: OutputsDefinition
 
     @classmethod
@@ -195,6 +336,10 @@ class WorkflowDefinition:
                 StepDefinition.from_step(step)
                 for step in workflow.steps
             ],
+            inputs=InputsDefinition.from_parameters([
+                reference.parameter for reference in
+                workflow.find_parameters()
+            ]),
             outputs=OutputsDefinition.from_results({
                 "out": workflow.result
             } if workflow.result else {})
@@ -210,6 +355,7 @@ class WorkflowDefinition:
         return {
             "cwlVersion": 1.2,
             "class": "Workflow",
+            "inputs": self.inputs.render(),
             "outputs": self.outputs.render(),
             "steps": {
                 step.name: step.render()

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -20,7 +20,7 @@ current workflow.
 
 from attrs import define
 from collections.abc import Mapping
-from typing import TypedDict, NotRequired, get_args, Union, cast
+from typing import TypedDict, NotRequired, get_args, Union, cast, Any
 
 from dewret.workflow import Reference, Raw, Workflow, Step, Task, StepReference, Parameter
 from dewret.tasks import run
@@ -276,7 +276,7 @@ class OutputsDefinition:
         name: str
 
     @classmethod
-    def from_results(cls, results: dict[str, StepReference]) -> "OutputsDefinition":
+    def from_results(cls, results: dict[str, StepReference[Any]]) -> "OutputsDefinition":
         """Takes a mapping of results into a CWL structure.
 
         [TODO] For now, it assumes the output type is a string.

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -122,15 +122,28 @@ class OutputsDefinition:
         outputs: sequence of results from a workflow.
     """
 
+    outputs: dict[str, "OutputReferenceDefinition"]
+
     @define
     class OutputReferenceDefinition:
+        """CWL-renderable reference to a specific output.
+
+        Attributes:
+            vartype: type of variable
+            name: fully-qualified name of the referenced step output.
+        """
         vartype: str
         name: str
 
-    outputs: dict[str, OutputReferenceDefinition]
-
     @classmethod
     def from_results(cls, results: dict[str, StepReference]) -> "OutputsDefinition":
+        """Takes a mapping of results into a CWL structure.
+
+        [TODO] For now, it assumes the output type is a string.
+
+        Returns:
+            CWL-like structure representing all workflow outputs.
+        """
         return cls(
             outputs={
                 key: cls.OutputReferenceDefinition(

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -42,7 +42,7 @@ class ReferenceDefinition:
         Args:
             ref: reference to convert.
         """
-        return cls(source=str(ref))
+        return cls(source=ref.name)
 
     def render(self) -> dict[str, RawType]:
         """Render to a dict-like structure.
@@ -63,12 +63,12 @@ class StepDefinition:
     needed for valid CWL.
 
     Attributes:
-        id: identifier to call this step by.
+        name: identifier to call this step by.
         run: task to execute for this step.
         in_: inputs from values or other steps.
     """
 
-    id: str
+    name: str
     run: str
     in_: Mapping[str, ReferenceDefinition | Raw]
 
@@ -82,7 +82,7 @@ class StepDefinition:
             step: step to convert.
         """
         return cls(
-            id=step.id,
+            name=step.name,
             run=step.task.name,
             in_={
                 key: (
@@ -152,7 +152,7 @@ class WorkflowDefinition:
             "cwlVersion": 1.2,
             "class": "Workflow",
             "steps": {
-                step.id: step.render()
+                step.name: step.render()
                 for step in self.steps
             }
         }

--- a/src/dewret/tasks.py
+++ b/src/dewret/tasks.py
@@ -126,6 +126,24 @@ class TaskManager:
         """
         return self.backend.run(__workflow__, task, **kwargs)
 
+    def unwrap(self, task: Lazy) -> Target:
+        """Unwraps a lazy-evaluated function to get the function.
+
+        Ideally, we could use the `__wrapped__` property but not all
+        workflow engines support this, and most importantly, dask has
+        only done so as of 2024.03.
+
+        Args:
+            task: task to be unwrapped.
+
+        Returns:
+            Original target.
+
+        Raises:
+            RuntimeError: if the task is not a wrapped function.
+        """
+        return self.backend.unwrap(task)
+
     def ensure_lazy(self, task: Any) -> Lazy | None:
         """Evaluate a single task for a known workflow.
 
@@ -161,6 +179,7 @@ class TaskManager:
 _manager = TaskManager()
 lazy = _manager.make_lazy
 ensure_lazy = _manager.ensure_lazy
+unwrap = _manager.unwrap
 evaluate = _manager.evaluate
 run = _manager
 

--- a/src/dewret/tasks.py
+++ b/src/dewret/tasks.py
@@ -110,11 +110,12 @@ class TaskManager:
         """
         return self.backend.lazy
 
-    def __call__(self, task: Lazy, **kwargs: Any) -> Workflow:
+    def __call__(self, task: Lazy, simplify_ids: bool = False, **kwargs: Any) -> Workflow:
         """Execute the lazy evalution.
 
         Arguments:
             task: the task to evaluate.
+            simplify_ids: when we finish running, make nicer step names?
             **kwargs: any arguments to pass to the task.
 
         Returns:
@@ -122,7 +123,7 @@ class TaskManager:
         """
         workflow = Workflow()
         result = self.backend.run(workflow, task, **kwargs)
-        return Workflow.from_result(result)
+        return Workflow.from_result(result, simplify_ids=simplify_ids)
 
 _manager = TaskManager()
 lazy = _manager.make_lazy

--- a/src/dewret/utils.py
+++ b/src/dewret/utils.py
@@ -35,7 +35,7 @@ def is_raw(var: Any) -> bool:
     does not. Instead, we explicitly make the full union in the statement below.
     """
     # isinstance(var, RawType | list[RawType] | dict[str, RawType])
-    return isinstance(var, str | float | bool | bytes | int | None | list[RawType] | dict[str, RawType])
+    return isinstance(var, str | float | bool | bytes | int | None | list | dict)
 
 def hasher(construct: FirmType) -> str:
     """Consistently hash a RawType or tuple structure.

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -319,6 +319,8 @@ class Workflow:
         )
         self.steps.append(step)
         return_type = inspect.signature(inspect.unwrap(fn)).return_annotation
+        if return_type is inspect._empty:
+            raise TypeError(f"All tasks should have a type annotation.")
         return StepReference(self, step, return_type)
 
     @staticmethod
@@ -599,13 +601,14 @@ class StepReference(Generic[U], Reference):
         """Hashable reference to the step (and field)."""
         return f"{self.step.id}/{self.field}"
 
+    @property
     def return_type(self) -> type[U]:
         """Type that this step reference will resolve to.
 
         Returns:
             Python type indicating the final result type.
         """
-        return self.typ
+        return self.type
 
     @property
     def name(self) -> str:

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -657,9 +657,11 @@ def is_task(task: Lazy) -> bool:
     Returns:
         True if `task` is indeed a task.
     """
+    from .tasks import unwrap
     try:
-        func = inspect.unwrap(task)
-        return bool(func.__step_expression__)
-    except:
+        func = unwrap(task)
+        if hasattr(func, "__step_expression__"):
+            return bool(func.__step_expression__)
+    except Exception as e:
         ...
     return False

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -291,7 +291,7 @@ class Workflow:
 
 
 class WorkflowComponent:
-    """Base class for anything tied to an individual `Workflow`.
+    """Base class for anything directly tied to an individual `Workflow`.
 
     Attributes:
         __workflow__: the `Workflow` that this is tied to.
@@ -309,7 +309,7 @@ class WorkflowComponent:
         self.__workflow__ = workflow
 
 class WorkflowLinkedComponent(Protocol):
-    """Base class for classes dynamically tied to a `Workflow`."""
+    """Protocol for objects dynamically tied to a `Workflow`."""
 
     @property
     def __workflow__(self) -> Workflow:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for dewret."""

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -3,7 +3,7 @@ from dewret.tasks import task, run
 JUMP: float = 1.0
 
 @task()
-def increase(num: int) -> float:
+def increase(num: int | float) -> float:
     """Add 1 to a number."""
     return num + JUMP
 

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -1,0 +1,29 @@
+from dewret.tasks import task, run
+
+JUMP: float = 1.0
+
+@task()
+def increase(num: int) -> float:
+    """Add 1 to a number."""
+    return num + JUMP
+
+@task()
+def increment(num: int) -> int:
+    """Increment an integer."""
+    return num + 1
+
+@task()
+def double(num: int | float) -> int | float:
+    """Double an integer."""
+    return 2 * num
+
+@task()
+def mod10(num: int) -> int:
+    """Double an integer."""
+    return num % 10
+
+@task()
+def sum(left: int | float, right: int | float) -> int | float:
+    """Add two integers."""
+    return left + right
+

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -88,10 +88,6 @@ def test_complex_cwl_references() -> None:
     )
     workflow = run(result, simplify_ids=True)
     rendered = render(workflow)
-    hsh_increment = hasher(("increment", ("num", "int|23")))
-    hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}/out")))
-    hsh_mod10 = hasher(("mod10", ("num", f"increment-{hsh_increment}/out")))
-    hsh_sum = hasher(("sum", ("left", f"double-{hsh_double}/out"), ("right", f"mod10-{hsh_mod10}/out")))
 
     assert rendered == yaml.safe_load(f"""
         cwlVersion: 1.2

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -86,7 +86,7 @@ def test_complex_cwl_references() -> None:
         left=double(num=increment(num=23)),
         right=mod10(num=increment(num=23))
     )
-    workflow = run(result)
+    workflow = run(result, simplify_ids=True)
     rendered = render(workflow)
     hsh_increment = hasher(("increment", ("num", "int|23")))
     hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}/out")))
@@ -97,30 +97,30 @@ def test_complex_cwl_references() -> None:
         cwlVersion: 1.2
         class: Workflow
         steps:
-          increment-{hsh_increment}:
+          increment-1:
             run: increment
             in:
                 num:
                     default: 23
             out: [out]
-          double-{hsh_double}:
+          double-1:
             run: double
             in:
                 num:
-                    source: increment-{hsh_increment}/out
+                    source: increment-1/out
             out: [out]
-          mod10-{hsh_mod10}:
+          mod10-1:
             run: mod10
             in:
                 num:
-                    source: increment-{hsh_increment}/out
+                    source: increment-1/out
             out: [out]
-          sum-{hsh_sum}:
+          sum-1:
             run: sum
             in:
                 left:
-                    source: double-{hsh_double}/out
+                    source: double-1/out
                 right:
-                    source: mod10-{hsh_mod10}/out
+                    source: mod10-1/out
             out: [out]
     """)

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -30,7 +30,7 @@ def test_cwl() -> None:
         outputs:
           out:
             outputSource: increment-{hsh}/out
-            type: string
+            type: int
         steps:
           increment-{hsh}:
             run: increment
@@ -58,7 +58,7 @@ def test_cwl_references() -> None:
         outputs:
           out:
             outputSource: double-{hsh_double}/out
-            type: string
+            type: [int, double]
         steps:
           increment-{hsh_increment}:
             run: increment
@@ -93,7 +93,7 @@ def test_complex_cwl_references() -> None:
         outputs:
           out:
             outputSource: sum-1/out
-            type: string
+            type: [int, double]
         steps:
           increment-1:
             run: increment

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -11,6 +11,21 @@ def increment(num: int) -> int:
     """Increment an integer."""
     return num + 1
 
+@task()
+def double(num: int) -> int:
+    """Double an integer."""
+    return 2 * num
+
+@task()
+def mod10(num: int) -> int:
+    """Double an integer."""
+    return num % 10
+
+@task()
+def sum(left: int, right: int) -> int:
+    """Add two integers."""
+    return left + right
+
 def test_cwl() -> None:
     """Check whether we can produce simple CWL.
 
@@ -19,7 +34,7 @@ def test_cwl() -> None:
     result = increment(num=3)
     workflow = run(result)
     rendered = render(workflow)
-    hsh = hasher(('increment', ('num', 'int|3')))
+    hsh = hasher(("increment", ("num", "int|3")))
 
     assert rendered == yaml.safe_load(f"""
         cwlVersion: 1.2
@@ -30,4 +45,82 @@ def test_cwl() -> None:
             in:
                 num:
                     default: 3
+            out: [out]
+    """)
+
+def test_cwl_references() -> None:
+    """Check whether we can link between steps.
+
+    Produces CWL that can has references between steps.
+    """
+    result = double(num=increment(num=3))
+    workflow = run(result)
+    rendered = render(workflow)
+    hsh_increment = hasher(("increment", ("num", "int|3")))
+    hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}/out")))
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        steps:
+          increment-{hsh_increment}:
+            run: increment
+            in:
+                num:
+                    default: 3
+            out: [out]
+          double-{hsh_double}:
+            run: double
+            in:
+                num:
+                    source: increment-{hsh_increment}/out
+            out: [out]
+    """)
+
+def test_complex_cwl_references() -> None:
+    """Check whether we can link between multiple steps.
+
+    Produces CWL that can has references between steps.
+    """
+    result = sum(
+        left=double(num=increment(num=23)),
+        right=mod10(num=increment(num=23))
+    )
+    workflow = run(result)
+    rendered = render(workflow)
+    hsh_increment = hasher(("increment", ("num", "int|23")))
+    hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}/out")))
+    hsh_mod10 = hasher(("mod10", ("num", f"increment-{hsh_increment}/out")))
+    hsh_sum = hasher(("sum", ("left", f"double-{hsh_double}/out"), ("right", f"mod10-{hsh_mod10}/out")))
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        steps:
+          increment-{hsh_increment}:
+            run: increment
+            in:
+                num:
+                    default: 23
+            out: [out]
+          double-{hsh_double}:
+            run: double
+            in:
+                num:
+                    source: increment-{hsh_increment}/out
+            out: [out]
+          mod10-{hsh_mod10}:
+            run: mod10
+            in:
+                num:
+                    source: increment-{hsh_increment}/out
+            out: [out]
+          sum-{hsh_sum}:
+            run: sum
+            in:
+                left:
+                    source: double-{hsh_double}/out
+                right:
+                    source: mod10-{hsh_mod10}/out
+            out: [out]
     """)

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -1,0 +1,80 @@
+"""Verify CWL can be made with split up and nested calls."""
+
+import yaml
+from dewret.tasks import nested_task, run
+from dewret.renderers.cwl import render
+from dewret.workflow import Lazy
+from ._lib.extra import double, mod10, sum, increase
+
+STARTING_NUMBER: int = 23
+
+@nested_task()
+def algorithm() -> int | float:
+    """Creates a graph of task calls."""
+    num = STARTING_NUMBER
+    left = double(num=increase(num=STARTING_NUMBER))
+    right = increase(num=increase(num=17))
+    return sum(
+        left=left,
+        right=right
+    )
+
+def test_nested_task() -> None:
+    """Check whether we can link between multiple steps and have parameters.
+
+    Produces CWL that has references between multiple steps.
+    """
+    workflow = run(algorithm(), simplify_ids=True)
+    rendered = render(workflow)
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          JUMP:
+            label: JUMP
+            type: double
+        outputs:
+          out:
+            outputSource: sum-1/out
+            type: string
+        steps:
+          increase-1:
+            run: increase
+            in:
+                JUMP:
+                    source: JUMP
+                num:
+                    default: 17
+            out: [out]
+          increase-2:
+            run: increase
+            in:
+                JUMP:
+                    source: JUMP
+                num:
+                    source: increase-1/out
+            out: [out]
+          increase-3:
+            run: increase
+            in:
+                JUMP:
+                    source: JUMP
+                num:
+                    default: 23
+            out: [out]
+          double-1:
+            run: double
+            in:
+                num:
+                    source: increase-3/out
+            out: [out]
+          sum-1:
+            run: sum
+            in:
+                left:
+                    source: double-1/out
+                right:
+                    source: increase-2/out
+            out: [out]
+    """)

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -37,7 +37,7 @@ def test_nested_task() -> None:
         outputs:
           out:
             outputSource: sum-1/out
-            type: string
+            type: [int, double]
         steps:
           increase-1:
             run: increase

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -35,7 +35,7 @@ def test_cwl_parameters() -> None:
         outputs:
           out:
             outputSource: rotate-1/out
-            type: string
+            type: int
         steps:
           rotate-1:
             run: rotate
@@ -70,7 +70,7 @@ def test_complex_parameters() -> None:
         outputs:
           out:
             outputSource: sum-1/out
-            type: string
+            type: [int, double]
         steps:
           rotate-1:
             run: rotate

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,105 @@
+"""Verify CWL can be made with parameters."""
+
+import yaml
+from dewret.tasks import task, run
+from dewret.renderers.cwl import render
+from dewret.utils import hasher
+from dewret.workflow import Workflow, param
+
+from ._lib.extra import double, mod10, sum
+
+INPUT_NUM = 3
+
+@task()
+def rotate(num: int) -> int:
+    """Rotate an integer."""
+    return (num + INPUT_NUM) % INPUT_NUM
+
+
+def test_cwl_parameters() -> None:
+    """Check whether we can spot input parameters.
+
+    Produces CWL that reference input parameters based on local/global variables.
+    """
+    result = rotate(num=3)
+    workflow = run(result, simplify_ids=True)
+    rendered = render(workflow)
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          INPUT_NUM:
+            label: INPUT_NUM
+            type: int
+        outputs:
+          out:
+            outputSource: rotate-1/out
+            type: string
+        steps:
+          rotate-1:
+            run: rotate
+            in:
+                num:
+                    default: 3
+                INPUT_NUM:
+                    source: INPUT_NUM
+            out: [out]
+    """)
+
+
+def test_complex_parameters() -> None:
+    """Check whether we can link between multiple steps and have parameters.
+
+    Produces CWL that has references between multiple steps.
+    """
+    result = sum(
+        left=double(num=rotate(num=23)),
+        right=rotate(num=rotate(num=23))
+    )
+    workflow = run(result, simplify_ids=True)
+    rendered = render(workflow)
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          INPUT_NUM:
+            label: INPUT_NUM
+            type: int
+        outputs:
+          out:
+            outputSource: sum-1/out
+            type: string
+        steps:
+          rotate-1:
+            run: rotate
+            in:
+                INPUT_NUM:
+                    source: INPUT_NUM
+                num:
+                    default: 23
+            out: [out]
+          double-1:
+            run: double
+            in:
+                num:
+                    source: rotate-1/out
+            out: [out]
+          rotate-2:
+            run: rotate
+            in:
+                INPUT_NUM:
+                    source: INPUT_NUM
+                num:
+                    source: rotate-1/out
+            out: [out]
+          sum-1:
+            run: sum
+            in:
+                left:
+                    source: double-1/out
+                right:
+                    source: rotate-2/out
+            out: [out]
+    """)


### PR DESCRIPTION
### What has changed?

Mainly two new constructs:

* __nested tasks__: tasks that are evaluated at _render_ time, not execution time, and so (a) do not appear in the output graph explicitly and (b) consist solely of tasks/nested_tasks being mixed together, and returned.
* __input parameters__: we spot and capture global variables that we see being used by tasks, so that they are turned into input parameters for the workflow.
* __typehinting__: of tasks is now retained (after decoration) as it was declared, so that return values of lazy-evaluated functions will be treated as their original types, and the type-checker should validate code as if they were the original imperative functions.

### Why has this changed?

This allows us to create reusable, composable workflows. This provides enough features to construct useful complex workflows.

### How to review?

Try the new examples in `workflows.md` and experiment with rewiring them.