### PR TITLE
Can we make dewret not attrs-only?

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -215,7 +215,7 @@ steps:
 
 Each step, by default, is treated as having
 a single result. However, we allow a mechanism
-for specifying multiple fields, using `attrs`.
+for specifying multiple fields, using `attrs` or `dataclasses`.
 
 Where needed, fields can be accessed outside of tasks
 by dot notation and dewret will map that access to a
@@ -239,6 +239,77 @@ As code:
 >>> from numpy import random
 >>> from dewret.tasks import nested_task
 >>> @define
+... class PackResult:
+...     hearts: int
+...     clubs: int
+...     spades: int
+...     diamonds: int
+>>>
+>>> @task()
+... def shuffle(max_cards_per_suit: int) -> PackResult:
+...    """Fill a random pile from a card deck, suit by suit."""
+...    return PackResult(
+...        hearts=random.randint(max_cards_per_suit),
+...        clubs=random.randint(max_cards_per_suit),
+...        spades=random.randint(max_cards_per_suit),
+...        diamonds=random.randint(max_cards_per_suit)
+...    )
+>>> @task()
+... def sum(left: int, right: int) -> int:
+...    return left + right
+>>> red_total = sum(
+...     left=shuffle(max_cards_per_suit=13).hearts,
+...     right=shuffle(max_cards_per_suit=13).diamonds
+... )
+>>> workflow = construct(red_total, simplify_ids=True)
+>>> cwl = render(workflow)
+>>> yaml.dump(cwl, sys.stdout, indent=2)
+class: Workflow
+cwlVersion: 1.2
+inputs: {}
+outputs:
+  out:
+    label: out
+    outputSource: sum-1/out
+    type: int
+steps:
+  shuffle-1:
+    in:
+      max_cards_per_suit:
+        default: 13
+    out:
+      clubs:
+        label: clubs
+        type: int
+      diamonds:
+        label: diamonds
+        type: int
+      hearts:
+        label: hearts
+        type: int
+      spades:
+        label: spades
+        type: int
+    run: shuffle
+  sum-1:
+    in:
+      left:
+        source: shuffle-1/hearts
+      right:
+        source: shuffle-1/diamonds
+    out:
+    - out
+    run: sum
+
+```
+
+Here, we show the same example with `dataclasses`.
+
+```python
+>>> from dataclasses import dataclass
+>>> from numpy import random
+>>> from dewret.tasks import nested_task
+>>> @dataclass
 ... class PackResult:
 ...     hearts: int
 ...     clubs: int

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -21,11 +21,11 @@ current workflow.
 from attrs import define, has as attrs_has, fields as attrs_fields, AttrsInstance
 from dataclasses import is_dataclass, fields as dataclass_fields
 from collections.abc import Mapping
-from typing import TypedDict, NotRequired, get_args, Union, cast, Any, Callable, Iterable, TYPE_CHECKING
+from typing import TypedDict, NotRequired, get_args, Union, cast, Any
 from types import UnionType
 
 from dewret.workflow import Reference, Raw, Workflow, Step, StepReference, Parameter
-from dewret.utils import RawType, flatten, FieldProtocol, DataclassProtocol
+from dewret.utils import RawType, flatten, DataclassProtocol
 
 InputSchemaType = Union[str, "CommandInputSchema", list[str], list["InputSchemaType"]]
 

--- a/src/dewret/tasks.py
+++ b/src/dewret/tasks.py
@@ -36,6 +36,7 @@ from functools import cached_property
 from collections.abc import Callable
 from typing import Any, ParamSpec, TypeVar, cast
 from attrs import has as attrs_has
+from dataclasses import is_dataclass
 
 from .utils import is_raw
 from .workflow import (
@@ -278,7 +279,7 @@ def task(nested: bool = False) -> Callable[[Callable[Param, RetType]], Callable[
                 elif is_task(value):
                     if not nested:
                         raise TypeError("You reference a task inside another task, but it is not a nested_task - this will not be found!")
-                elif attrs_has(value):
+                elif attrs_has(value) or is_dataclass(value):
                     ...
                 elif nested:
                     raise NotImplementedError(f"Nested tasks must now only refer to global parameters, raw or tasks, not objects: {var}")

--- a/src/dewret/utils.py
+++ b/src/dewret/utils.py
@@ -27,11 +27,12 @@ RawType = Union[BasicType, list["RawType"], dict[str, "RawType"]]
 FirmType = BasicType | list["FirmType"] | dict[str, "FirmType"] | tuple["FirmType", ...]
 
 class DataclassProtocol(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Any]]
+    """Format of a dataclass.
 
-class FieldProtocol(Protocol):
-    name: str
-    type: type
+    Since dataclasses do not expose a proper type, we use this to
+    represent them.
+    """
+    __dataclass_fields__: ClassVar[dict[str, Any]]
 
 
 def flatten(value: Any) -> RawType:

--- a/src/dewret/utils.py
+++ b/src/dewret/utils.py
@@ -19,12 +19,20 @@ General types and functions to centralize common logic.
 
 import hashlib
 import json
-from typing import Any, cast, Union
+from typing import Any, cast, Union, Protocol, ClassVar
 from collections.abc import Sequence, Mapping
 
 BasicType = str | float | bool | bytes | int | None
 RawType = Union[BasicType, list["RawType"], dict[str, "RawType"]]
 FirmType = BasicType | list["FirmType"] | dict[str, "FirmType"] | tuple["FirmType", ...]
+
+class DataclassProtocol(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+class FieldProtocol(Protocol):
+    name: str
+    type: type
+
 
 def flatten(value: Any) -> RawType:
     """Takes a Raw-like structure and makes it RawType.

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -632,6 +632,7 @@ class StepReference(Generic[U], Reference):
             Another StepReference specific to the requested field.
 
         Raises:
+            AttributeError: if this field is not present in the dataclass.
             RuntimeError: if this field is not available, or we do not have a structured result.
         """
         if self._field is None:

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -622,7 +622,7 @@ class StepReference(Generic[U], Reference):
     def __getattr__(self, attr: str) -> "StepReference"[Any]:
         """Reference to a field within this result, if possible.
 
-        If the result is an attrs-class, this will pull out an individual
+        If the result is an attrs-class or dataclass, this will pull out an individual
         field for use as input to other tasks, or global output of the workflow.
 
         Args:


### PR DESCRIPTION
Can we swap attrs for something else, if desired?

Following the discussion in #10, rather than doing a general purpose layer for returned types, this implements an either/or approach, where either `dataclasses` or `attrs` may be used to specify a multi-part result. It does not touch `attrs` in the dewret internals, and so (for now) it remains a dependency.