### PR TITLE
Explain globals input (1-22)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -166,10 +166,9 @@ and treat them as parameters. It will try to get the type from the typehint, or
 the value that you have set it to. This only works for basic types (and dict/lists of
 those).
 
-While global variables are implicit input to the Python function **note that**:
+**Important:** global parameters should be treated as **read-only** and must not be updated.
 
-1. in CWL, they will be rendered as explicit global input to a step
-2. as input, they are read-only, and must not be updated
+While global variables are implicit input to the Python function **note that** in CWL, they will be rendered as explicit global input to a step.
 
 For example:
 ```python

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -166,6 +166,11 @@ and treat them as parameters. It will try to get the type from the typehint, or
 the value that you have set it to. This only works for basic types (and dict/lists of
 those).
 
+While global variables are implicit input to the Python function **note that**:
+
+1. in CWL, they will be rendered as explicit global input to a step
+2. as input, they are read-only, and must not be updated
+
 For example:
 ```python
 >>> INPUT_NUM = 3


### PR DESCRIPTION
Adds a brief explanation around the parameters section to the documentation, explaining how context is handled.