### PR TITLE
[Requires #25] Clarify input behaviour

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,7 @@
+# Glossary
+
+Step
+: Corresponds to a CWL [Step](https://www.commonwl.org/user_guide/topics/workflows.html#workflows)
+
+Task
+: Corresponds to a CWL [Process](https://www.commonwl.org/user_guide/introduction/basic-concepts.html#processes-and-requirements)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,10 +29,10 @@ class: Workflow
 cwlVersion: 1.2
 outputs:
   out:
-    outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out
+    outputSource: increment-e138626779553199eb2bd678356b640f-num
     type: int
 steps:
-  increment-012ef3b3ffb9d15c3f2837aa4bb20a8d:
+  increment-e138626779553199eb2bd678356b640f-num
     in:
       num:
         default: 3
@@ -61,22 +61,26 @@ and backends, as well as bespoke serialization or formatting.
 ...     return num + 1
 >>>
 >>> result = increment(num=3)
->>> workflow = construct(result)
+>>> workflow = construct(result, simplify_ids=True)
 >>> cwl = render(workflow)
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
-inputs: {}
+inputs:
+  increment-1-num:
+    default: 3
+    label: increment-1-num
+    type: int
 outputs:
   out:
     label: out
-    outputSource: increment-012ef3b3ffb9d15c3f2837aa4bb20a8d/out
+    outputSource: increment-1/out
     type: int
 steps:
-  increment-012ef3b3ffb9d15c3f2837aa4bb20a8d:
+  increment-1:
     in:
       num:
-        default: 3
+        source: increment-1-num
     out:
     - out
     run: increment

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -59,7 +59,15 @@ In code, this would be:
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
-inputs: {}
+inputs:
+  increment-1-num:
+    default: 23
+    label: increment-1-num
+    type: int
+  increment-2-num:
+    default: 23
+    label: increment-2-num
+    type: int
 outputs:
   out:
     label: out
@@ -69,14 +77,21 @@ steps:
   double-1:
     in:
       num:
-        source: increment-1/out
+        source: increment-2/out
     out:
     - out
     run: double
   increment-1:
     in:
       num:
-        default: 23
+        source: increment-1-num
+    out:
+    - out
+    run: increment
+  increment-2:
+    in:
+      num:
+        source: increment-2-num
     out:
     - out
     run: increment
@@ -187,7 +202,12 @@ class: Workflow
 cwlVersion: 1.2
 inputs:
   INPUT_NUM:
+    default: 3
     label: INPUT_NUM
+    type: int
+  rotate-1-num:
+    default: 5
+    label: rotate-1-num
     type: int
 outputs:
   out:
@@ -200,7 +220,7 @@ steps:
       INPUT_NUM:
         source: INPUT_NUM
       num:
-        default: 5
+        source: rotate-1-num
     out:
     - out
     run: rotate
@@ -239,7 +259,12 @@ class: Workflow
 cwlVersion: 1.2
 inputs:
   INPUT_NUM:
+    default: 3
     label: INPUT_NUM
+    type: int
+  num:
+    default: 3
+    label: num
     type: int
 outputs:
   out:
@@ -252,7 +277,7 @@ steps:
       INPUT_NUM:
         source: INPUT_NUM
       num:
-        default: 3
+        source: num
     out:
     - out
     run: rotate
@@ -339,7 +364,15 @@ As code:
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
-inputs: {}
+inputs:
+  shuffle-1-max_cards_per_suit:
+    default: 13
+    label: shuffle-1-max_cards_per_suit
+    type: int
+  shuffle-2-max_cards_per_suit:
+    default: 13
+    label: shuffle-2-max_cards_per_suit
+    type: int
 outputs:
   out:
     label: out
@@ -349,7 +382,25 @@ steps:
   shuffle-1:
     in:
       max_cards_per_suit:
-        default: 13
+        source: shuffle-1-max_cards_per_suit
+    out:
+      clubs:
+        label: clubs
+        type: int
+      diamonds:
+        label: diamonds
+        type: int
+      hearts:
+        label: hearts
+        type: int
+      spades:
+        label: spades
+        type: int
+    run: shuffle
+  shuffle-2:
+    in:
+      max_cards_per_suit:
+        source: shuffle-2-max_cards_per_suit
     out:
       clubs:
         label: clubs
@@ -367,7 +418,7 @@ steps:
   sum-1:
     in:
       left:
-        source: shuffle-1/hearts
+        source: shuffle-2/hearts
       right:
         source: shuffle-1/diamonds
     out:
@@ -410,7 +461,15 @@ Here, we show the same example with `dataclasses`.
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
-inputs: {}
+inputs:
+  shuffle-1-max_cards_per_suit:
+    default: 13
+    label: shuffle-1-max_cards_per_suit
+    type: int
+  shuffle-2-max_cards_per_suit:
+    default: 13
+    label: shuffle-2-max_cards_per_suit
+    type: int
 outputs:
   out:
     label: out
@@ -420,7 +479,25 @@ steps:
   shuffle-1:
     in:
       max_cards_per_suit:
-        default: 13
+        source: shuffle-1-max_cards_per_suit
+    out:
+      clubs:
+        label: clubs
+        type: int
+      diamonds:
+        label: diamonds
+        type: int
+      hearts:
+        label: hearts
+        type: int
+      spades:
+        label: spades
+        type: int
+    run: shuffle
+  shuffle-2:
+    in:
+      max_cards_per_suit:
+        source: shuffle-2-max_cards_per_suit
     out:
       clubs:
         label: clubs
@@ -438,7 +515,7 @@ steps:
   sum-1:
     in:
       left:
-        source: shuffle-1/hearts
+        source: shuffle-2/hearts
       right:
         source: shuffle-1/diamonds
     out:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -127,7 +127,15 @@ Changing the workflow to include two increments with distinct input parameters r
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
-inputs: {}
+inputs:
+  increment-1-num:
+    default: 3
+    label: increment-1-num
+    type: int
+  increment-2-num:
+    default: 23
+    label: increment-2-num
+    type: int
 outputs:
   out:
     label: out
@@ -144,14 +152,14 @@ steps:
   increment-1:
     in:
       num:
-        default: 3
+        source: increment-1-num
     out:
     - out
     run: increment
   increment-2:
     in:
       num:
-        default: 23
+        source: increment-2-num
     out:
     - out
     run: increment

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -334,7 +334,6 @@ As code:
 ```python
 >>> from attrs import define
 >>> from numpy import random
->>> from dewret.tasks import nested_task
 >>> @define
 ... class PackResult:
 ...     hearts: int
@@ -431,7 +430,6 @@ Here, we show the same example with `dataclasses`.
 ```python
 >>> from dataclasses import dataclass
 >>> from numpy import random
->>> from dewret.tasks import nested_task
 >>> @dataclass
 ... class PackResult:
 ...     hearts: int

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -8,6 +8,7 @@ We can pull in dewret tools to produce CWL with a small number of imports.
 >>> import sys
 >>> import yaml
 >>> from dewret.tasks import task, construct
+>>> from dewret.workflow import param
 >>> from dewret.renderers.cwl import render
 
 ```
@@ -114,13 +115,14 @@ steps:
 
 ```
 
-Notice that the `increment` tasks appears only once in the CWL workflow definition, despite being referenced twice in the python code above. 
-Changing the workflow to include two increments with distinct input parameters renders a workflow with two calls to increment:
+Notice that the `increment` tasks appears twice in the CWL workflow definition, being referenced twice in the python code above. 
+This duplication can be avoided by explicitly indicating that the parameters are the same, with the `param` function.
 
 ```python
+>>> num = param("num", default=3)
 >>> result = sum(
-...     left=double(num=increment(num=23)),
-...     right=mod10(num=increment(num=3))
+...     left=double(num=increment(num=num)),
+...     right=mod10(num=increment(num=num))
 ... )
 >>> workflow = construct(result, simplify_ids=True)
 >>> cwl = render(workflow)
@@ -128,13 +130,9 @@ Changing the workflow to include two increments with distinct input parameters r
 class: Workflow
 cwlVersion: 1.2
 inputs:
-  increment-1-num:
+  num:
     default: 3
-    label: increment-1-num
-    type: int
-  increment-2-num:
-    default: 23
-    label: increment-2-num
+    label: num
     type: int
 outputs:
   out:
@@ -145,21 +143,14 @@ steps:
   double-1:
     in:
       num:
-        source: increment-2/out
+        source: increment-1/out
     out:
     - out
     run: double
   increment-1:
     in:
       num:
-        source: increment-1-num
-    out:
-    - out
-    run: increment
-  increment-2:
-    in:
-      num:
-        source: increment-2-num
+        source: num
     out:
     - out
     run: increment

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -15,7 +15,7 @@ We can pull in dewret tools to produce CWL with a small number of imports.
 ## Dependencies
 
 Specifying step interdependencies is possible by combining lazy-evaluated function
-calls.
+calls. The output series of steps is not guaranteed to be in order of execution.
 
 Dewret hashes the parameters to identify and unify steps. This lets you do, for example:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -166,6 +166,11 @@ and treat them as parameters. It will try to get the type from the typehint, or
 the value that you have set it to. This only works for basic types (and dict/lists of
 those).
 
+While global variables are implicit input to the Python function **note that**:
+
+1. in CWL, they will be rendered as explicit global input to a step
+2. as input, they are read-only, and must not be updated
+
 For example:
 ```python
 >>> INPUT_NUM = 3

--- a/src/dewret/__init__.py
+++ b/src/dewret/__init__.py
@@ -2,6 +2,7 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0

--- a/src/dewret/backends/backend_dask.py
+++ b/src/dewret/backends/backend_dask.py
@@ -101,4 +101,5 @@ def run(workflow: Workflow | None, task: Lazy) -> StepReference[Any]:
         raise RuntimeError(
             f"{task} is not a dask delayed, perhaps you tried to mix backends?"
         )
-    return task.compute(__workflow__=workflow)
+    result = task.compute(__workflow__=workflow)
+    return result

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -1,29 +1,39 @@
-from dewret.tasks import task
+from dewret.tasks import task, subworkflow
 
 JUMP: float = 1.0
+
 
 @task()
 def increase(num: int | float) -> float:
     """Add 1 to a number."""
     return num + JUMP
 
+
 @task()
 def increment(num: int) -> int:
     """Increment an integer."""
     return num + 1
+
 
 @task()
 def double(num: int | float) -> int | float:
     """Double an integer."""
     return 2 * num
 
+
 @task()
 def mod10(num: int) -> int:
     """Double an integer."""
     return num % 10
+
 
 @task()
 def sum(left: int | float, right: int | float) -> int | float:
     """Add two integers."""
     return left + right
 
+
+@subworkflow()
+def triple_and_one(num: int | float) -> int | float:
+    """Triple a number by doubling and adding again, then add 1."""
+    return sum(left=sum(left=double(num=num), right=num), right=1)

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -1,31 +1,76 @@
 """Verify CWL output is OK."""
 
 import yaml
-from dewret.tasks import construct
+from dewret.tasks import construct, task
 from dewret.renderers.cwl import render
 from dewret.utils import hasher
+from dewret.workflow import param
 
-from ._lib.extra import (
-    increment,
-    double,
-    mod10,
-    sum
-)
+from ._lib.extra import increment, double, mod10, sum, triple_and_one
 
-def test_cwl() -> None:
+
+@task()
+def pi() -> float:
+    """Returns pi."""
+    import math
+
+    return math.pi
+
+
+@task()
+def floor(num: int | float) -> int:
+    """Converts int/float to int."""
+    return int(num)
+
+
+def test_basic_cwl() -> None:
     """Check whether we can produce simple CWL.
 
-    Produces simplest possible CWL from a workflow.
+    Produces simplest possible CWL from a workflow, using
+    a pure function.
     """
-    result = increment(num=3)
+    result = pi()
     workflow = construct(result)
     rendered = render(workflow)
-    hsh = hasher(("increment", ("num", "int|3")))
+    hsh = hasher(("pi",))
 
     assert rendered == yaml.safe_load(f"""
         cwlVersion: 1.2
         class: Workflow
         inputs: {{}}
+        outputs:
+          out:
+            label: out
+            outputSource: pi-{hsh}/out
+            type: double
+        steps:
+          pi-{hsh}:
+            run: pi
+            in: {{}}
+            out: [out]
+    """)
+
+
+def test_cwl_with_parameter() -> None:
+    """Check whether we can move raw input to parameters.
+
+    Produces CWL for a call with a changeable raw value, that is converted
+    to a parameter, if and only if we are calling from outside a nested task.
+    """
+    result = increment(num=3)
+    workflow = construct(result)
+    rendered = render(workflow)
+    num_param = list(workflow.find_parameters())[0]
+    hsh = hasher(("increment", ("num", f"int|:param:{num_param.unique_name}")))
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          increment-{hsh}-num:
+            label: increment-{hsh}-num
+            type: int
+            default: 3
         outputs:
           out:
             label: out
@@ -36,9 +81,141 @@ def test_cwl() -> None:
             run: increment
             in:
                 num:
-                    default: 3
+                    source: increment-{hsh}-num
             out: [out]
     """)
+
+
+def test_cwl_without_default() -> None:
+    """Check whether we can produce CWL without a default value.
+
+    Uses a manually created parameter to avoid a default.
+    """
+    my_param = param("my_param", typ=int)
+
+    result = increment(num=my_param)
+    workflow = construct(result)
+    rendered = render(workflow)
+    hsh = hasher(("increment", ("num", "int|:param:my_param")))
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          my_param:
+            label: my_param
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: increment-{hsh}/out
+            type: int
+        steps:
+          increment-{hsh}:
+            run: increment
+            in:
+                num:
+                    source: my_param
+            out: [out]
+    """)
+
+
+def test_cwl_with_subworkflow() -> None:
+    """Check whether we can produce a subworkflow from CWL."""
+    my_param = param("num", typ=int)
+    result = increment(num=floor(num=triple_and_one(num=increment(num=my_param))))
+    workflow = construct(result, simplify_ids=True)
+    rendered, subworkflows = render(workflow)
+
+    assert len(subworkflows) == 1
+    assert isinstance(subworkflows, dict)
+    name, subworkflow = list(subworkflows.items())[0]
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: increment-2/out
+            type: int
+        steps:
+          floor-1:
+             in:
+               num:
+                 source: triple_and_one-1/out
+             out: [out]
+             run: floor
+          increment-1:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          increment-2:
+             in:
+               num:
+                 source: floor-1/out
+             out: [out]
+             run: increment
+          triple_and_one-1:
+             in:
+               num:
+                 source: increment-1/out
+             out: [out]
+             run: triple_and_one
+    """)
+
+    assert subworkflow == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+          sum-1-2-right:
+            default: 1
+            label: sum-1-2-right
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: sum-1-2/out
+            type:
+            - int
+            - double
+        steps:
+          double-1-1:
+            in:
+              num:
+                source: num
+            out:
+            - out
+            run: double
+          sum-1-1:
+            in:
+              left:
+                source: double-1-1/out
+              right:
+                source: num
+            out:
+            - out
+            run: sum
+          sum-1-2:
+            in:
+              left:
+                source: sum-1-1/out
+              right:
+                source: sum-1-2-right
+            out:
+            - out
+            run: sum
+    """)
+
 
 def test_cwl_references() -> None:
     """Check whether we can link between steps.
@@ -48,13 +225,20 @@ def test_cwl_references() -> None:
     result = double(num=increment(num=3))
     workflow = construct(result)
     rendered = render(workflow)
-    hsh_increment = hasher(("increment", ("num", "int|3")))
+    num_param = list(workflow.find_parameters())[0]
+    hsh_increment = hasher(
+        ("increment", ("num", f"int|:param:{num_param.unique_name}"))
+    )
     hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}/out")))
 
     assert rendered == yaml.safe_load(f"""
         cwlVersion: 1.2
         class: Workflow
-        inputs: {{}}
+        inputs:
+          increment-{hsh_increment}-num:
+            label: increment-{hsh_increment}-num
+            type: int
+            default: 3
         outputs:
           out:
             label: out
@@ -65,7 +249,7 @@ def test_cwl_references() -> None:
             run: increment
             in:
                 num:
-                    default: 3
+                    source: increment-{hsh_increment}-num
             out: [out]
           double-{hsh_double}:
             run: double
@@ -75,22 +259,28 @@ def test_cwl_references() -> None:
             out: [out]
     """)
 
+
 def test_complex_cwl_references() -> None:
     """Check whether we can link between multiple steps.
 
     Produces CWL that has references between multiple steps.
     """
-    result = sum(
-        left=double(num=increment(num=23)),
-        right=mod10(num=increment(num=23))
-    )
+    result = sum(left=double(num=increment(num=23)), right=mod10(num=increment(num=23)))
     workflow = construct(result, simplify_ids=True)
     rendered = render(workflow)
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
         class: Workflow
-        inputs: {}
+        inputs:
+          increment-1-num:
+            label: increment-1-num
+            type: int
+            default: 23
+          increment-2-num:
+            label: increment-2-num
+            type: int
+            default: 23
         outputs:
           out:
             label: out
@@ -101,13 +291,19 @@ def test_complex_cwl_references() -> None:
             run: increment
             in:
                 num:
-                    default: 23
+                    source: increment-1-num
+            out: [out]
+          increment-2:
+            run: increment
+            in:
+                num:
+                    source: increment-2-num
             out: [out]
           double-1:
             run: double
             in:
                 num:
-                    source: increment-1/out
+                    source: increment-2/out
             out: [out]
           mod10-1:
             run: mod10

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -7,15 +7,15 @@ from ._lib.extra import double, sum, increase
 
 STARTING_NUMBER: int = 23
 
+
 @nested_task()
 def algorithm() -> int | float:
     """Creates a graph of task calls."""
     left = double(num=increase(num=STARTING_NUMBER))
-    right = increase(num=increase(num=17))
-    return sum(
-        left=left,
-        right=right
-    )
+    num = increase(num=17)
+    right = increase(num=num)
+    return sum(left=left, right=right)
+
 
 def test_nested_task() -> None:
     """Check whether we can link between multiple steps and have parameters.
@@ -32,6 +32,15 @@ def test_nested_task() -> None:
           JUMP:
             label: JUMP
             type: double
+            default: 1.0
+          increase-3-num:
+            default: 23
+            label: increase-3-num
+            type: int
+          increase-1-num:
+            default: 17
+            label: increase-1-num
+            type: int
         outputs:
           out:
             label: out
@@ -44,7 +53,7 @@ def test_nested_task() -> None:
                 JUMP:
                     source: JUMP
                 num:
-                    default: 17
+                    source: increase-1-num
             out: [out]
           increase-2:
             run: increase
@@ -60,7 +69,7 @@ def test_nested_task() -> None:
                 JUMP:
                     source: JUMP
                 num:
-                    default: 23
+                    source: increase-3-num
             out: [out]
           double-1:
             run: double

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -8,42 +8,54 @@ from dewret.renderers.cwl import render
 
 STARTING_NUMBER: int = 23
 
+
 @define
 class SplitResult:
     """Test class showing two named values, using attrs."""
+
     first: int
     second: float
+
 
 @dataclass
 class SplitResultDataclass:
     """Test class showing two named values, using dataclasses."""
+
     first: int
     second: float
+
 
 @task()
 def combine(left: int, right: float) -> float:
     """Sum two values."""
     return left + right
 
+
 @nested_task()
 def algorithm() -> float:
     """Sum two split values."""
     return combine(left=split().first, right=split().second)
 
+
 @nested_task()
 def algorithm_with_dataclasses() -> float:
     """Sum two split values."""
-    return combine(left=split_into_dataclass().first, right=split_into_dataclass().second)
+    return combine(
+        left=split_into_dataclass().first, right=split_into_dataclass().second
+    )
+
 
 @task()
 def split() -> SplitResult:
     """Create a result with two fields."""
     return SplitResult(first=1, second=2)
 
+
 @task()
 def split_into_dataclass() -> SplitResultDataclass:
     """Create a result with two fields."""
     return SplitResultDataclass(first=1, second=2)
+
 
 def test_nested_task() -> None:
     """Check whether we can link between multiple steps and have parameters.
@@ -82,6 +94,7 @@ def test_nested_task() -> None:
             run: split
     """)
 
+
 def test_field_of_nested_task() -> None:
     """Tests whether a directly-output nested task can have fields."""
     workflow = construct(split().first, simplify_ids=True)
@@ -109,6 +122,7 @@ def test_field_of_nested_task() -> None:
             run: split
     """)
 
+
 def test_field_of_nested_task_into_dataclasses() -> None:
     """Tests whether a directly-output nested task can have fields."""
     workflow = construct(split_into_dataclass().first, simplify_ids=True)
@@ -135,6 +149,7 @@ def test_field_of_nested_task_into_dataclasses() -> None:
                 type: double
             run: split_into_dataclass
     """)
+
 
 def test_complex_field_of_nested_task() -> None:
     """Tests whether a task can insert result fields into other steps."""
@@ -171,9 +186,11 @@ def test_complex_field_of_nested_task() -> None:
             run: split
     """)
 
+
 def test_complex_field_of_nested_task_with_dataclasses() -> None:
     """Tests whether a task can insert result fields into other steps."""
-    workflow = construct(algorithm_with_dataclasses(), simplify_ids=True)
+    result = algorithm_with_dataclasses()
+    workflow = construct(result, simplify_ids=True, nested=False)
     rendered = render(workflow)
 
     assert rendered == yaml.safe_load("""

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -190,7 +190,7 @@ def test_complex_field_of_nested_task() -> None:
 def test_complex_field_of_nested_task_with_dataclasses() -> None:
     """Tests whether a task can insert result fields into other steps."""
     result = algorithm_with_dataclasses()
-    workflow = construct(result, simplify_ids=True, nested=False)
+    workflow = construct(result, simplify_ids=True)
     rendered = render(workflow)
 
     assert rendered == yaml.safe_load("""


### PR DESCRIPTION
### What does this PR do?

The fundamental problem it solves is that, as per feedback, when a raw value is passed as an argument to a function, it should not simply be captured as a default value for that function call, but be turned into a global parameter. However, this behaviour does not make sense for raw (literal) variables inside tasks/nested tasks. In practice, this turned out to be quite a major change with a number of corner cases.

Consequently, this PR includes the following:

* subworkflows: nested tasks that are not transparent to the outside workflow, effectively having a scope and preventing literal values in nested tasks (when marked as "subworkflows" from bubbling up to the global parameters).
* parameter-naming: unnamed parameters are given names that should be predictable, but will remain distinct from each other. A potentially undesirable sideeffect is that two tasks called with the same raw variable (i.e. one not declared as a parameter) will always have separate defaults, even if they were originally the same static variable. There does not appear to be a straightforward (non-convoluted/brittle) way around this.
* the renderers can return multiple (related) workflows if subworkflows are discovered.

### How to test?

Run through the documented workflows in the `docs` folder, and ensure they make sense with the input code.

### Who can review?

@elleryames or @KamenDimitrov97 