### PR TITLE
Nested tasks should not get globals as arguments

### DIFF
--- a/src/dewret/tasks.py
+++ b/src/dewret/tasks.py
@@ -501,9 +501,6 @@ def task(
                             raise TypeError(
                                 f"Task {fn.__name__} returned output of type {type(output)}, which is not a lazy function for this backend."
                             )
-                        # for var, value in kwargs.items():
-                        #    if isinstance(value, ParameterReference):
-                        #        value.parameter.register_caller(workflow)
                         step_reference = evaluate(lazy_fn, __workflow__=workflow)
                     else:
                         nested_workflow = Workflow(name=fn.__name__)
@@ -514,23 +511,11 @@ def task(
                                     var, typ=value.__type__, tethered=nested_workflow
                                 ),
                             )
-                            for var, value in kwargs.items()
+                            for var, value in original_kwargs.items()
                         }
                         with in_nested_task():
                             output = fn(**nested_kwargs)
                         nested_workflow = _manager(output, __workflow__=nested_workflow)
-                        # lazy_fn = ensure_lazy(output)
-                        # if lazy_fn is None:
-                        #    raise TypeError(
-                        #        f"Task {fn.__name__} returned output of type {type(output)}, which is not a lazy function for this backend."
-                        #    )
-                        # if not is_in_nested_task():
-                        #    for var, value in kwargs.items():
-                        #        if isinstance(value, ParameterReference):
-                        #            value.parameter.register_caller(nested_workflow)
-                        # step_reference = evaluate(lazy_fn, __workflow__=nested_workflow)
-                        # nested_workflow = step_reference.__workflow__
-                        # nested_workflow.set_result(step_reference)
                         step_reference = workflow.add_nested_step(
                             fn.__name__, nested_workflow, kwargs
                         )

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -1,0 +1,72 @@
+"""Check subworkflow behaviour is as expected."""
+
+import yaml
+from dewret.tasks import construct, subworkflow, task
+from dewret.renderers.cwl import render
+from dewret.workflow import param
+
+from ._lib.extra import increment, sum
+
+CONSTANT = 3
+
+
+@task()
+def to_int(num: int | float) -> int:
+    """Cast to an int."""
+    return int(num)
+
+
+@subworkflow()
+def add_constant(num: int | float) -> int:
+    """Add a global constant to a number."""
+    return to_int(num=sum(left=num, right=CONSTANT))
+
+
+def test_subworkflows_can_use_globals() -> None:
+    """Check whether we can produce a subworkflow from CWL."""
+    my_param = param("num", typ=int)
+    result = increment(num=add_constant(num=increment(num=my_param)))
+    workflow = construct(result, simplify_ids=True)
+    rendered, subworkflows = render(workflow)
+
+    assert len(subworkflows) == 1
+    assert isinstance(subworkflows, dict)
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          CONSTANT:
+            label: CONSTANT
+            default: 3
+            type: int
+          num:
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: increment-2/out
+            type: int
+        steps:
+          increment-1:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          increment-2:
+             in:
+               num:
+                 source: add_constant-1/out
+             out: [out]
+             run: increment
+          add_constant-1:
+             in:
+               CONSTANT:
+                 source: CONSTANT
+               num:
+                 source: increment-1/out
+             out: [out]
+             run: add_constant
+    """)


### PR DESCRIPTION
### What does this PR do?

Only passes real arguments, not globals, to a nested task / subworkflow when it is called.

### How to test?

Ensure `tests/test_subworkflows.py` passses CI.

### Who can test?

@philtweir (minor change)