### PR TITLE
Fix subworkflows and globals

### DIFF
--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -218,7 +218,7 @@ def to_cwl_type(typ: type) -> str | list[str]:
         return "string"
     else:
         if configuration("allow_complex_types"):
-            return typ.__name__
+            return typ if isinstance(typ, str) else typ.__name__
         raise TypeError(f"Cannot render complex type ({typ}) to CWL")
 
 

--- a/src/dewret/tasks.py
+++ b/src/dewret/tasks.py
@@ -467,7 +467,7 @@ def task(
                         kwargs[var] = ParameterReference(
                             workflow, param(var, value, tethered=False)
                         )
-                    elif is_task(value):
+                    elif is_task(value) or ensure_lazy(value) is not None:
                         if not nested and _workaround_check_value_is_task(
                             fn, var, value
                         ):

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -97,7 +97,8 @@ class LazyEvaluation(Lazy, Generic[RetType]):
         is attempted.
         """
         tb = make_traceback()
-        return self._fn(*args, **kwargs, __traceback__=tb)
+        result = self._fn(*args, **kwargs, __traceback__=tb)
+        return result
 
 
 Target = Callable[..., Any]
@@ -581,7 +582,11 @@ class Workflow:
         step = step_maker(self, task, kwargs, raw_as_parameter=raw_as_parameter)
         self.steps.append(step)
         return_type = step.return_type
-        if return_type is inspect._empty:
+        if (
+            return_type is inspect._empty
+            and not isinstance(fn, type)
+            and not inspect.isclass(fn)
+        ):
             raise TypeError("All tasks should have a type annotation.")
         return StepReference(self, step, return_type)
 

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -1,7 +1,9 @@
 """Check subworkflow behaviour is as expected."""
 
+from typing import Callable
+from queue import Queue
 import yaml
-from dewret.tasks import construct, subworkflow, task
+from dewret.tasks import construct, subworkflow, task, factory
 from dewret.renderers.cwl import render
 from dewret.workflow import param
 
@@ -9,11 +11,41 @@ from ._lib.extra import increment, sum
 
 CONSTANT = 3
 
+QueueFactory: Callable[..., "Queue[int]"] = factory(Queue)
+
+GLOBAL_QUEUE = QueueFactory()
+
+
+@task()
+def pop(queue: "Queue[int]") -> int:
+    """Remove element of a queue."""
+    return queue.get()
+
 
 @task()
 def to_int(num: int | float) -> int:
     """Cast to an int."""
     return int(num)
+
+
+@task()
+def add_and_queue(num: int, queue: "Queue[int]") -> "Queue[int]":
+    """Add a global constant to a number."""
+    queue.put(num)
+    return queue
+
+
+@subworkflow()
+def make_queue(num: int | float) -> "Queue[int]":
+    """Add a number to a queue."""
+    queue = QueueFactory()
+    return add_and_queue(num=to_int(num=num), queue=queue)
+
+
+@subworkflow()
+def get_global_queue(num: int | float) -> "Queue[int]":
+    """Add a number to a global queue."""
+    return add_and_queue(num=to_int(num=num), queue=GLOBAL_QUEUE)
 
 
 @subworkflow()
@@ -23,7 +55,7 @@ def add_constant(num: int | float) -> int:
 
 
 def test_subworkflows_can_use_globals() -> None:
-    """Check whether we can produce a subworkflow from CWL."""
+    """Produce a subworkflow that uses a global."""
     my_param = param("num", typ=int)
     result = increment(num=add_constant(num=increment(num=my_param)))
     workflow = construct(result, simplify_ids=True)
@@ -69,4 +101,92 @@ def test_subworkflows_can_use_globals() -> None:
                  source: increment-1/out
              out: [out]
              run: add_constant
+    """)
+
+
+def test_subworkflows_can_use_factories() -> None:
+    """Produce a subworkflow that uses a factory."""
+    my_param = param("num", typ=int)
+    result = pop(queue=make_queue(num=increment(num=my_param)))
+    workflow = construct(result, simplify_ids=True)
+    rendered, subworkflows = render(workflow, allow_complex_types=True)
+
+    assert len(subworkflows) == 1
+    assert isinstance(subworkflows, dict)
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: pop-1/out
+            type: int
+        steps:
+          increment-1:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          make_queue-1:
+             in:
+               num:
+                 source: increment-1/out
+             out: [out]
+             run: make_queue
+          pop-1:
+             in:
+               queue:
+                 source: make_queue-1/out
+             out: [out]
+             run: pop
+    """)
+
+
+def test_subworkflows_can_use_global_factories() -> None:
+    """Check whether we can produce a subworkflow that uses a global factory."""
+    my_param = param("num", typ=int)
+    result = pop(queue=get_global_queue(num=increment(num=my_param)))
+    workflow = construct(result, simplify_ids=True)
+    rendered, subworkflows = render(workflow, allow_complex_types=True)
+
+    assert len(subworkflows) == 1
+    assert isinstance(subworkflows, dict)
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: pop-1/out
+            type: int
+        steps:
+          increment-1:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          get_global_queue-1:
+             in:
+               num:
+                 source: increment-1/out
+             out: [out]
+             run: get_global_queue
+          pop-1:
+             in:
+               queue:
+                 source: get_global_queue-1/out
+             out: [out]
+             run: pop
     """)


### PR DESCRIPTION
### What does this PR do?

Fixes the ability of subworkflows to use global factories and constants.

### How to test?

Ensure CI runs.

### Who can test?

@philtweir (minor changes)