### PR TITLE
Readded snakemake with fixed mypy issues.

### DIFF
--- a/docs/renderer_tutorial.md
+++ b/docs/renderer_tutorial.md
@@ -1,0 +1,421 @@
+# Step-by-Step Guide to Writing a Custom Renderer
+
+## 1. Understand the Target Workflow Language
+
+
+Before writing any code, it is essential to fully understand the target workflow language. This includes syntax, structure, and specific requirements. By breaking down each key `dewret.workflow` task into smaller components, you can better map your workflow definitions to the target language.
+
+### Example: 
+
+In Snakemake, a workflow task is generally created by:
+1. Defining the task. - `rule process_data`
+2. Defining the input required for the rule to run(dependencies). - `input: "data/raw_data.txt"`
+3. Defining the output required for the rule to be considered finished. - `output: "data/processed_data.txt"`
+4. Defining the actual work that the task will do. - in this case:`shell: ...`
+
+```bash
+rule process_data: # Example Snakemake rule/task
+    input:
+        "data/raw_data.txt"
+    output:
+        output_file="data/processed_data.txt"
+    run:
+        with open(output.output_file, "w") as f:
+            f.write("data")
+
+        return output_file
+```
+
+## 2. Create WorkflowDefinition.
+
+The WorkflowDefinition class is responsible for transforming each step from a constructed `dewret` workflow into an executable step in the target workflow language (e.g. a Snakemake rule). This class should encapsulate workflow-level information, such as the list of steps to be executed, and any workflow-scope input/ouput. It should also contain a class method that initializes the `WorkflowDefinition` from an `dewret` `Workflow` (such as `from_workflow` below), and a method that renders the workflow as a Python dict (as in the `render` method below).
+
+### Example:
+```python
+@define
+class WorkflowDefinition:
+    steps: list[StepDefinition]
+
+    # Returns a WorkflowDefinition instanace.
+    # Steps contains all of the tasks you want to convert to the target WL tasks.
+    @classmethod
+    def from_workflow(cls, workflow: Workflow) -> "WorkflowDefinition":
+        return cls(steps=[StepDefinition.from_step(step) for step in workflow.steps])
+
+    # Returns each task as a Snakemake executable rule.
+    def render(self) -> dict[str, RawType]:
+        return {
+            f"rule {step.name.replace("-", "_")}": step.render() for step in self.steps
+        }
+```
+
+## 3. Create a StepDefinition.
+
+Create a StepsDefinition class create each of the code blocks needed for a rule(step) to be executable in Snakemake.
+When you have defined each block in your target workflow language task from [step 1](#1-understand-the-target-workflow-language),
+you can go ahead and create, for each of the code blocks required to run a Snakemake rule, a `BlockDefinition` to handle the rendering of each block.
+
+### Example:
+
+In the Snakemake example, we have created:
+1. `InputDefinition` - Handles the input block, which contains what is required for a rule to be executed. It also handles the params block since the code for extracting the input and params blocks is similar.
+2. `RunDefinition` - Handles the run block which contains the instructions needed for this specific task. 
+3. `OutputDefinition` - Handles the output block which is required for the rule to be considered successfully finished.
+
+```python
+@define
+class StepDefinition:
+    """Represents a Snakemake-renderable step definition in a dewret workflow.
+
+    Attributes:
+        name (str): The name of the step.
+        run (str): The run block definition for the step.
+        params (List[str]): The parameter definitions for the step.
+        output (list[str]: The output definition for the step.
+        input (List[str]): The input definitions for the step.
+
+    Methods:
+        from_step(cls, step: Step) -> "StepDefinition": Constructs a StepDefinition
+            object from a Step object, extracting step information and components
+            from the step and converting them to Snakemake format.
+        render(self) -> dict[str, MainTypes]: Renders the step definition as a dictionary
+            suitable for use in Snakemake workflows.
+    """
+
+    # You can consider each step as a separate rule.
+    # Each field in this class represents a separate block in the rule definition
+    name: str # name of the rule
+    input: list[str] # Input block
+    params: list[str] # Params block
+    output: list[str] # Output block
+    run: list[str] # Run block - where the instructions for the task are
+
+    @classmethod
+    def from_step(cls, step: Step) -> "StepDefinition":
+        """Constructs a StepDefinition object from a Step.
+
+        Args:
+            step (Step): The Step object from which step information and components
+                are extracted.
+
+        Returns:
+            StepDefinition: A StepDefinition object containing the converted step
+                information and components.
+        """
+        input_block = InputDefinition.from_step(step).render()
+        run_block = RunDefinition.from_task(step.task).render()
+        output_block = OutputDefinition.from_step(step).render()
+        return cls(
+            name=step.name, 
+            run=run_block,
+            params=input_block["params"],
+            input=input_block["inputs"],
+            output=output_block,
+        )
+
+    def render(self) -> dict[str, MainTypes]:
+        """Renders the step definition as a dictionary.
+
+        Returns:
+            dict[str, MainTypes]: A dictionary containing the components of the step
+                definition, for use in Snakemake workflows.
+        """
+        return {
+            "run": self.run,
+            "input": self.input,
+            "params": self.params,
+            "output": self.output,
+        }
+```
+
+## 4. Create the Separate block definitions.
+
+In this step, you'll define classes to handle the rendering of each code block required for a rule (step) to be executable in the target workflow language. Each of these classes will encapsulate the logic for converting parts of a workflow step into the target language format.
+
+### Example:
+For the Snakemake workflow language, we will define:
+
+1. InputDefinition: Handles the input block and parameter block.
+2. RunDefinition: Handles the run block.
+3. OutputDefinition: Handles the output block.
+
+#### InputDefinition: 
+
+The InputDefinition class is responsible for rendering the inputs and parameters required for a Snakemake rule.
+
+```python
+@define
+class InputDefinition:
+    """Represents input and parameter definitions block for a Snakemake-renderable workflow step.
+
+    Attributes:
+        inputs (List[str]): A list of input definitions.
+        params (List[str]): A list of parameter definitions.
+
+    Methods:
+        from_step(cls, step: Step) -> "InputDefinition": Constructs an InputDefinition
+            object from a Step object, extracting inputs and parameters and converting
+            them to Snakemake-compatible format.
+        render(self) -> dict[str, str]: Renders the input and parameter definitions
+            as a dictionary for use in Snakemake Input and Params blocks.
+    """
+
+    # As we already mention input and params block have similar generation
+    # So it made sence to encapsulate them into one Definition
+    inputs: list[str]
+    params: list[str]
+
+    @classmethod
+    def from_step(cls, step: Step) -> "InputDefinition":
+        """Constructs an InputDefinition object from a Step.
+
+        Args:
+            step (Step): The Step object from which input and parameter block definitions are
+                extracted.
+
+        Returns:
+            InputDefinition: An InputDefinition object.
+        """
+        params = []
+        inputs = []
+        # The keys represent the names of the arguments of the @tasks in our snakemake_workflow.py.
+        # The params represent the values.
+        for key, param in step.arguments.items():
+            # We check if the param is a reference.
+            # If it is then it's an input requirement for the rule to run, so we put it in the input block
+            if isinstance(param, Reference):
+                ref = ReferenceDefinition.from_reference(param).render().replace("-","_").replace("/out", ".output")
+                input = f"{key}=rules.{ref}.output_file"
+                inputs.append(input)
+                params.append(input + ",")
+            # If it's not - we put it in the params block for use in the RunDefinition
+            elif isinstance(param, Raw):
+                customized = f"{key}={to_snakemake_type(param)},"
+                params.append(customized)
+
+        # Since the params must be comma separated except the last one - we remove the last comma
+        if params:
+            params[len(params) - 1] = params[len(params) - 1].replace(",", "")
+
+        return cls(inputs=inputs, params=params)
+
+    def render(self) -> dict[str, list[str]]:
+        """Renders the input and parameter definitions as a dictionary.
+
+        Returns:
+            dict[str, list[MainTypes]]: A dictionary containing the input and parameter definitions,
+                for use in Snakemake Input and Params blocks.
+        """
+        return {"inputs": self.inputs, "params": self.params}
+
+```
+
+#### RunDefinition:
+
+The RunDefinition class is responsible for rendering the run block, which contains the actual instructions for the task.
+
+```python
+@define
+class RunDefinition:
+    # This is where we handle the execution of the task itself.
+    """Represents a Snakemake-renderable run block for a dewret workflow step.
+
+    Attributes:
+        method_name (str): The name of the method to be executed in the snakefile run block.
+        rel_import (str): The relative import path of the method.
+        args (List[str]): The arguments to be passed to the method.
+
+    Methods:
+        from_task(cls, task: Task) -> "RunDefinition": Constructs a RunDefinition
+            object from a Task object, extracting method information and arguments
+            from the task and converting them to Snakemake-compatible format.
+
+        render(self) -> list[str]: A list containing the import statement and the method
+            call statement, for use in Snakemake run block.
+    """
+
+    method_name: str
+    rel_import: str
+    args: list[str]
+
+    @classmethod
+    def from_task(cls, task: Task) -> "RunDefinition":
+        """Constructs a RunDefinition object from a Task.
+
+        Args:
+            task (Task): The Task object from which method information and arguments
+                are extracted.
+
+        Returns:
+            RunDefinition: A RunDefinition object containing the converted method
+                information and arguments.
+        """
+        # Since we can import our snakemake_workflow.py @tasks we need the relative path
+        relative_path = get_method_rel_path(task.target)
+        # If we need to make any customization to the import
+        rel_import = f"{relative_path}"
+
+        args = get_method_args(task.target)
+        signature = [
+            f"{param_name}=params.{param_name}"
+            for param_name in args.parameters.keys()
+        ]
+
+        return cls(method_name=task.name, rel_import=rel_import, args=signature)
+
+    def render(self) -> list[str]:
+        """Renders the run block as a list of strings.
+
+        Returns:
+            list[str]: A list containing the import statement and the method
+                call statement, for use in Snakemake run block.
+        """
+        signature = ", ".join(f"{arg}" for arg in self.args)
+        # The comma after the last element is mandatory for the structure of rule onces it's used in yaml.dump
+        return [
+            f"import {self.rel_import}\n",
+            f"{self.rel_import}.{self.method_name}({signature})\n",
+        ]
+```
+
+#### OutputDefinition: 
+
+The OutputDefinition class is responsible for rendering the output block, which specifies the output files or results that indicate the rule has successfully completed.
+
+```python
+@define
+class OutputDefinition:
+    """Represents the output definition block for a Snakemake-renderable workflow step.
+
+    Attributes:
+        output_file (str): The output file definition.
+
+    Methods:
+        from_step(cls, step: Step) -> "OutputDefinition": Constructs an OutputDefinition
+            object from a Step object, extracting and converting the output file definition
+            to Snakemake-compatible format.
+
+        render(self) -> list[str]: Renders the output definition as a list
+            suitable for use in Snakemake Output block.
+    """
+
+    output_file: str
+
+    @classmethod
+    def from_step(cls, step: Step) -> "OutputDefinition":
+        """Constructs an OutputDefinition object from a Step.
+
+        Args:
+            step (Step): The Step object from which the output file definition is extracted.
+
+        Returns:
+            OutputDefinition: An OutputDefinition object, for use in Snakemake Output block.
+        """
+        # Since snakemake commonly communicates using files.
+        # Output file must always be called - `output_file`
+        # Further code could be added to handled if it's a reference in case we want take care of multiple tasks writing to the same output file.
+        output_file = step.arguments["output_file"]
+        if isinstance(output_file, Raw):
+            args = to_snakemake_type(output_file)
+
+        return cls(output_file=args)
+
+    def render(self) -> list[str]:
+        """Renders the output definition as a list.
+
+        Returns:
+            list[str]: A list containing the output file definition, for use in a Snakemake Output block.
+        """
+        # The comma after the last element is mandatory for the structure of rule onces it's used in yaml.dump
+        # It adds the new line to the output block
+        return [
+            f"output_file={self.output_file}",
+        ]
+```
+
+Integrate these block definitions into the StepDefinition class as demonstrated in [Step 3](#3-create-a-stepsdefinition). Each StepDefinition will use these block definitions to render the complete step in the target workflow language.
+
+## 5. Helper methods.
+
+In this step, you'll define helper methods that will assist you in converting workflow components into the target workflow language format. In our case these methods will handle type conversion, extracting method arguments, and computing relative paths.
+
+### Example:
+We'll define the following helper methods for our Snakemake renderer:
+
+1. to_snakemake_type(param: Raw) -> str: Converts a raw type to a Snakemake-compatible Python type.
+2. get_method_args(func: Lazy) -> inspect.Signature: Retrieves the argument names and types of a lazy-evaluatable function.
+3. get_method_rel_path(func: Lazy) -> str: Computes the relative path of the module containing the given function.
+
+#### Type Conversion Helper:
+
+```python
+# Basic types returned from dewret will look like this "str|valueOfParam".
+# We'll need to convert them.
+def to_Snakemake_type(param: Raw) -> str:
+    typ = str(param)
+    if typ.__contains__("str"):
+        return f'"{typ.replace("str|", "")}"'
+    elif typ.__contains__("bool"):
+        return typ.replace("bool|", "")
+    elif typ.__contains__("dict"):
+        return typ.replace("dict|", "")
+    elif typ.__contains__("list"):
+        return typ.replace("list|", "")
+    elif typ.__contains__("float"):
+        return typ.replace("float|", "")
+    elif typ.__contains__("int"):
+        return typ.replace("int|", "")
+    else:
+        raise TypeError(f"Cannot render complex type ({typ})")
+```
+
+#### Argument Extraction Helper:
+
+```python
+# We need to get the signature of the method. 
+def get_method_args(func: Lazy) -> inspect.Signature:
+    args = inspect.signature(func)
+    return args
+
+```
+
+#### Relative Path Computation Helper:
+
+```python
+# Computes the relative path
+def get_method_rel_path(func: Lazy) -> str:
+    source_file = inspect.getsourcefile(func)
+    if source_file:
+        relative_path = os.path.relpath(source_file, start=os.getcwd())
+        module_name = os.path.splitext(relative_path)[0].replace(os.path.sep, ".")
+
+    return module_name
+```
+
+## Imports and custom types required in the SMK example:
+
+```python
+import os
+import yaml
+import inspect
+import typing
+
+from attrs import define
+from dewret.workflow import Lazy
+from dewret.workflow import Reference, Raw, Workflow, Step, Task
+from dewret.utils import BasicType
+
+RawType = typing.Union[BasicType, list[str], list["RawType"], dict[str, "RawType"]]
+```
+
+## To run this example: 
+
+1. Import the snakemake renderer into your @tasks file
+2. There's an example in [snakemake_tasks.py](../example/snakemake_renderer/basic_example/snakemake_tasks.py)
+3. Run it:
+```shell
+python snakemake_tasks.py
+```
+
+### Q: Should I add a brief description of dewret in step 1? Should link dewret types/docs etc here?
+### A: Get details on how that happens and probably yes.

--- a/example/snakemake_renderer/basic_example/snakemake_workflow.py
+++ b/example/snakemake_renderer/basic_example/snakemake_workflow.py
@@ -1,0 +1,176 @@
+"""Basic snakemake workflow.
+
+Useful as an example of a workflow with multiple tasks.
+
+```sh
+$ python snakemake_workflow.py
+```
+Since snakemake commonly communicates via the filesystem between workflow steps,
+each our tasks and hence steps writes its output to a file.
+This output can then be read by subsequent steps.
+
+For the current implementation, output files must be called "output_file".
+
+Running the example will generate a Snakefile with the following code:
+
+rule download_data_cbb4d1260b8b17d6693986ebfd833d53:
+    input:
+    output:
+        output_file="generated_smk/data/test_data.txt"
+    params:
+        data="4, 5, 7, 8, 0",
+        output_file="generated_smk/data/test_data.txt"
+    run:
+        import snakemake_tasks
+
+
+        snakemake_tasks.download_data(data=params.data, output_file=params.output_file)
+
+
+rule generate_report_b1f9747ed9903dcd9571246547b1767b:
+    input:
+        processed_data=rules.process_data_75213b5c31fed773cd1f7ca1dfb6ab5a.output.output_file
+    output:
+        output_file="results/report.txt"
+    params:
+        processed_data=rules.process_data_75213b5c31fed773cd1f7ca1dfb6ab5a.output.output_file,
+        multiple_arg="test2",
+        output_file="results/report.txt"
+    run:
+        import snakemake_tasks
+
+
+        snakemake_tasks.generate_report(processed_data=params.processed_data, multiple_arg=params.multiple_arg,
+        output_file=params.output_file)
+
+
+rule process_data_75213b5c31fed773cd1f7ca1dfb6ab5a:
+    input:
+        data_file=rules.download_data_cbb4d1260b8b17d6693986ebfd833d53.output.output_file
+    output:
+        output_file="generated_smk/data/processed_data.txt"
+    params:
+        data_file=rules.download_data_cbb4d1260b8b17d6693986ebfd833d53.output.output_file,
+        multiple_arg="test1",
+        output_file="generated_smk/data/processed_data.txt"
+    run:
+        import snakemake_tasks
+
+
+        snakemake_tasks.process_data(data_file=params.data_file, multiple_arg=params.multiple_arg,
+        output_file=params.output_file)
+
+In order to make the snakemake file be executable you need to:
+- manually add:
+rule all:
+    input:
+        "results/report.txt" # To make sure all connected rules are executed. For more information https://snakemake.readthedocs.io/
+- Change the order of the rules to match the order of execution.
+- Make sure all methods in run blocks are on the same line.
+- Remove @task annotation from the snakemake_workflow.py
+"""
+
+import yaml
+from dewret.tasks import task, construct
+from dewret.renderers.snakemake import render
+
+
+@task()
+def download_data(data: str, output_file: str) -> str:
+    """Example task to be converted to snakemake workflow rule.
+
+    This function writes the given data to the specified output file.
+
+    Args:
+        data (str): The data to be written to the output file.
+        output_file (str): The path to the output file where the data will be written.
+
+    Returns:
+        str: The path to the output file.
+    """
+    with open(output_file, "w") as f:
+        f.write(data)
+
+    return output_file
+
+
+@task()
+def process_data(data_file: str, multiple_arg: str, output_file: str) -> str:
+    """Example task to be converted to snakemake workflow rule.
+
+    This function reads data from a file, processes it by appending additional
+    strings, and writes the result to an output file.
+
+    Args:
+        data_file (str): The path to the input file containing the data to be processed.
+        multiple_arg (str): An additional string to be appended during processing.
+        output_file (str): The path to the output file where the processed data will be written.
+
+    Returns:
+        str: The path to the output file.
+    """
+    new_data = "test"
+
+    with open(data_file, "r") as f:
+        data = f.read()
+        new_data = data + new_data + multiple_arg
+
+    with open(output_file, "w") as f:
+        f.write(new_data)
+
+    return output_file
+
+
+@task()
+def generate_report(processed_data: str, multiple_arg: str, output_file: str) -> str:
+    """Example task to be converted to snakemake workflow.
+
+    This function generates a report by reading processed data from a file and
+    appending an additional string, then writes the report to an output file.
+
+    Args:
+        processed_data (str): The path to the input file containing the processed data.
+        multiple_arg (str): An additional string to be appended to the report.
+        output_file (str): The path to the output file where the report will be written.
+
+    Returns:
+        str: The path to the output file.
+    """
+    with open(processed_data, "r") as datafile:
+        data = datafile.read()
+
+    with open(output_file, "w") as f:
+        f.write(data + multiple_arg)
+
+    return output_file
+
+
+if __name__ == "__main__":
+    data = download_data(
+        data="4, 5, 7, 8, 0", output_file="generated_smk/data/test_data.txt"
+    )
+    processed_data = process_data(
+        data_file=data,
+        multiple_arg="test1",
+        output_file="generated_smk/data/processed_data.txt",
+    )
+    result = generate_report(
+        processed_data=processed_data,
+        multiple_arg="test2",
+        output_file="results/report.txt",
+    )
+
+    workflow = construct(result)
+    smk_output = render(workflow)
+
+    with open("Snakefile", "w") as file:
+        trans_table = str.maketrans(
+            {
+                "-": "   ",
+                "'": "",
+                "[": "",
+                "]": "",
+            }
+        )
+        smk_output = yaml.dump(smk_output, indent=4).translate(trans_table)
+        file.write(smk_output)

--- a/src/dewret/renderers/snakemake.py
+++ b/src/dewret/renderers/snakemake.py
@@ -1,0 +1,473 @@
+# Copyright 2014 Flax & Teal Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Snakemake Renderer.
+
+Outputs a [Snakemake](https://snakemake.github.io/) representation of the
+current workflow.
+
+"""
+
+import os
+import yaml
+import inspect
+import typing
+
+from attrs import define
+from dewret.utils import BasicType
+
+from dewret.workflow import (
+    Reference,
+    Raw,
+    Workflow,
+    Task,
+    Lazy,
+    BaseStep,
+)
+
+MainTypes = typing.Union[
+    BasicType, list[str], list["MainTypes"], dict[str, "MainTypes"]
+]
+
+
+@define
+class ReferenceDefinition:
+    """Represents a Snakemake-renderable internal reference.
+
+    Attributes:
+        source (str): The source of the internal reference.
+
+    Methods:
+        from_reference(cls, ref: Reference) -> "ReferenceDefinition": Constructs a
+            ReferenceDefinition object from a Reference object, extracting the source
+            of the reference.
+        render(self) -> str: Renders the internal reference definition as a string
+            suitable for use in Snakemake workflows.
+    """
+
+    source: str
+
+    @classmethod
+    def from_reference(cls, ref: Reference) -> "ReferenceDefinition":
+        """Build from a `Reference`.
+
+        Converts a `dewret.workflow.Reference` into a Snakemake-rendering object.
+
+        Args:
+            ref: reference to convert.
+        """
+        return cls(source=ref.name)
+
+    def render(self) -> str:
+        """Render the internal reference definition as a string.
+
+        Returns:
+            str: internal reference.
+        """
+        return self.source
+
+
+# TODO: Refactor: better way to handle the types.
+def to_snakemake_type(param: Raw) -> str:
+    """Convert a raw type to a corresponding Snakemake-compatible Python type.
+
+    This function maps raw types to their corresponding Python types as
+    used in Snakemake. Snakemake primarily uses Python types for its parameters,
+    and this function ensures that the provided type is appropriately converted.
+
+    Args:
+        param: The raw type to be converted, which can be of any type.
+
+    Returns:
+        A string representing the corresponding Python type for Snakemake.
+
+    Raises:
+        TypeError: If the parameter's type cannot be mapped to a known Python type.
+    """
+    typ = str(param)
+    if typ.__contains__("str"):
+        return f'"{typ.replace("str|", "")}"'
+    elif typ.__contains__("bool"):
+        return typ.replace("bool|", "")
+    elif typ.__contains__("dict"):
+        return typ.replace("dict|", "")
+    elif typ.__contains__("list"):
+        return typ.replace("list|", "")
+    elif typ.__contains__("float"):
+        return typ.replace("float|", "")
+    elif typ.__contains__("int"):
+        return typ.replace("int|", "")
+    else:
+        raise TypeError(f"Cannot render complex type ({typ})")
+
+
+def get_method_args(func: Lazy) -> inspect.Signature:
+    """Retrieve the argument names and types of a lazy-evaluatable function.
+
+    Args:
+        func: A function that adheres to the `Lazy` protocol.
+
+    Returns:
+        An `ItemsView` object containing the argument names and their corresponding
+        `inspect.Parameter` objects.
+    """
+    args = inspect.signature(func)
+
+    return args
+
+
+def get_method_rel_path(func: Lazy) -> typing.Any:
+    """Get the relative path of the module containing the given function.
+
+    Args:
+        func (Lazy): The function for which the relative path is to be determined.
+
+    Returns:
+        any: The relative path of the module containing the function.
+
+    Note:
+        This function relies on the `inspect` and `os` modules to compute its relative path.
+    """
+    # TODO: error handling
+    source_file = inspect.getsourcefile(func)
+    if source_file:
+        relative_path = os.path.relpath(source_file, start=os.getcwd())
+        module_name = os.path.splitext(relative_path)[0].replace(os.path.sep, ".")
+
+    return module_name
+
+
+@define
+class InputDefinition:
+    """Represents input and parameter definitions block for a Snakemake-renderable workflow step.
+
+    Attributes:
+        inputs (List[str]): A list of input definitions.
+        params (List[str]): A list of parameter definitions.
+
+    Methods:
+        from_step(cls, step: Step) -> "InputDefinition": Constructs an InputDefinition
+            object from a Step object, extracting inputs and parameters and converting
+            them to Snakemake-compatible format.
+        render(self) -> dict[str, str]: Renders the input and parameter definitions
+            as a dictionary for use in Snakemake Input and Params blocks.
+    """
+
+    inputs: list[str]
+    params: list[str]
+
+    @classmethod
+    def from_step(cls, step: BaseStep) -> "InputDefinition":
+        """Constructs an InputDefinition object from a Step.
+
+        Args:
+            step (Step): The Step object from which input and parameter block definitions are
+                extracted.
+
+        Returns:
+            InputDefinition: An InputDefinition object.
+        """
+        params = []
+        inputs = []
+        for key, param in step.arguments.items():
+            if isinstance(param, Reference):
+                ref = (
+                    ReferenceDefinition.from_reference(param)
+                    .render()
+                    .replace("-", "_")
+                    .replace("/out", ".output")
+                )
+                input = f"{key}=rules.{ref}.output_file"
+                inputs.append(input)
+                params.append(input + ",")
+            elif isinstance(param, Raw):
+                customized = f"{key}={to_snakemake_type(param)},"
+                params.append(customized)
+
+        if params:
+            params[len(params) - 1] = params[len(params) - 1].replace(",", "")
+
+        return cls(inputs=inputs, params=params)
+
+    def render(self) -> dict[str, list[str]]:
+        """Renders the input and parameter definitions as a dictionary.
+
+        Returns:
+            dict[str, list[MainTypes]]: A dictionary containing the input and parameter definitions,
+                for use in Snakemake Input and Params blocks.
+        """
+        return {"inputs": self.inputs, "params": self.params}
+
+
+@define
+class OutputDefinition:
+    """Represents the output definition block for a Snakemake-renderable workflow step.
+
+    Attributes:
+        output_file (str): The output file definition.
+
+    Methods:
+        from_step(cls, step: Step) -> "OutputDefinition": Constructs an OutputDefinition
+            object from a Step object, extracting and converting the output file definition
+            to Snakemake-compatible format.
+
+        render(self) -> list[str]: Renders the output definition as a list
+            suitable for use in Snakemake Output block.
+    """
+
+    output_file: str
+
+    @classmethod
+    def from_step(cls, step: BaseStep) -> "OutputDefinition":
+        """Constructs an OutputDefinition object from a Step.
+
+        Args:
+            step (Step): The Step object from which the output file definition is extracted.
+
+        Returns:
+            OutputDefinition: An OutputDefinition object, for use in Snakemake Output block.
+        """
+        # TODO: Error handling
+        # TODO: Better way to handling input/output files
+        output_file = step.arguments["output_file"]
+        if isinstance(output_file, Raw):
+            args = to_snakemake_type(output_file)
+
+        return cls(output_file=args)
+
+    def render(self) -> list[str]:
+        """Renders the output definition as a list.
+
+        Returns:
+            list[str]: A list containing the output file definition, for use in a Snakemake Output block.
+        """
+        # The comma after the last element is mandatory for the structure of rule onces it's used in yaml.dump
+        return [
+            f"output_file={self.output_file}",
+        ]
+
+
+@define
+class RunDefinition:
+    """Represents a Snakemake-renderable run block for a dewret workflow step.
+
+    Attributes:
+        method_name (str): The name of the method to be executed in the snakefile run block.
+        rel_import (str): The relative import path of the method.
+        args (List[str]): The arguments to be passed to the method.
+
+    Methods:
+        from_task(cls, task: Task) -> "RunDefinition": Constructs a RunDefinition
+            object from a Task object, extracting method information and arguments
+            from the task and converting them to Snakemake-compatible format.
+
+        render(self) -> list[str]: A list containing the import statement and the method
+            call statement, for use in Snakemake run block.
+    """
+
+    method_name: str
+    rel_import: str
+    args: list[str]
+
+    @classmethod
+    def from_task(cls, task: Task | Workflow) -> "RunDefinition":
+        """Constructs a RunDefinition object from a Task.
+
+        Args:
+            task (Task): The Task object from which method information and arguments
+                are extracted.
+
+        Returns:
+            RunDefinition: A RunDefinition object containing the converted method
+                information and arguments.
+        """
+        if isinstance(task, Task):
+            relative_path = get_method_rel_path(task.target)
+            rel_import = f"{relative_path}"
+            args = get_method_args(task.target)
+        else:
+            # TODO: Add implementation for multiple workflows
+            pass
+
+        signature = [
+            f"{param_name}=params.{param_name}" for param_name in args.parameters.keys()
+        ]
+
+        return cls(method_name=task.name, rel_import=rel_import, args=signature)
+
+    def render(self) -> list[str]:
+        """Renders the run block as a list of strings.
+
+        Returns:
+            list[str]: A list containing the import statement and the method
+                call statement, for use in Snakemake run block.
+        """
+        signature = ", ".join(f"{arg}" for arg in self.args)
+        # The comma after the last element is mandatory for the structure of rule onces it's used in yaml.dump
+        return [
+            f"import {self.rel_import}\n",
+            f"{self.rel_import}.{self.method_name}({signature})\n",
+        ]
+
+
+@define
+class StepDefinition:
+    """Represents a Snakemake-renderable step definition in a dewret workflow.
+
+    Attributes:
+        name (str): The name of the step.
+        run (str): The run block definition for the step.
+        params (List[str]): The parameter definitions for the step.
+        output (list[str]: The output definition for the step.
+        input (List[str]): The input definitions for the step.
+
+    Methods:
+        from_step(cls, step: Step) -> "StepDefinition": Constructs a StepDefinition
+            object from a Step object, extracting step information and components
+            from the step and converting them to Snakemake format.
+        render(self) -> dict[str, MainTypes]: Renders the step definition as a dictionary
+            suitable for use in Snakemake workflows.
+    """
+
+    name: str
+    run: list[str]
+    params: list[str]
+    output: list[str]
+    input: list[str]
+
+    @classmethod
+    def from_step(cls, step: BaseStep) -> "StepDefinition":
+        """Constructs a StepDefinition object from a Step.
+
+        Args:
+            step (Step): The Step object from which step information and components
+                are extracted.
+
+        Returns:
+            StepDefinition: A StepDefinition object containing the converted step
+                information and components.
+        """
+        input_block = InputDefinition.from_step(step).render()
+        run_block = RunDefinition.from_task(step.task).render()
+        output_block = OutputDefinition.from_step(step).render()
+        return cls(
+            name=step.name,
+            run=run_block,
+            params=input_block["params"],
+            input=input_block["inputs"],
+            output=output_block,
+        )
+
+    def render(self) -> dict[str, MainTypes]:
+        """Renders the step definition as a dictionary.
+
+        Returns:
+            dict[str, MainTypes]: A dictionary containing the components of the step
+                definition, for use in Snakemake workflows.
+        """
+        return {
+            "run": self.run,
+            "input": self.input,
+            "params": self.params,
+            "output": self.output,
+        }
+
+
+# TODO: Find out why the yaml.dump scrambles the order of the rules
+# TODO: Add a rule all: with input definition the last outputed file
+
+
+@define
+class WorkflowDefinition:
+    """Represents a Snakemake-renderable workflow definition from a dewret workflow.
+
+    Attributes:
+        steps (List[StepDefinition]): A list of StepDefinition objects representing the steps
+            in the workflow.
+
+    Methods:
+        from_workflow(cls, workflow: Workflow) -> "WorkflowDefinition": Constructs a WorkflowDefinition
+            object from a Workflow object, converting its steps to StepDefinition objects.
+
+        render(self) -> dict[str, MainTypes]: Renders the workflow definition as a dictionary
+            containing Snakemake rules, for use in Snakemake workflows.
+    """
+
+    steps: list[StepDefinition]
+
+    # TODO: Add a "rule all" definition
+    # In order for snakemake to execute multiple connected rules
+    # it needs a rule to define which is the target rule that connects all the multiple rules
+    @classmethod
+    def from_workflow(cls, workflow: Workflow) -> "WorkflowDefinition":
+        """Creates a WorkflowDefinition object from a Workflow object.
+
+        Args:
+            workflow (Workflow): The workflow to be rendered.
+
+        Returns:
+            str: WorkflowDefinition with definited steps.
+        """
+        return cls(steps=[StepDefinition.from_step(step) for step in workflow.steps])
+
+    def render(self) -> dict[str, MainTypes]:
+        """Render the WorkflowDefinition.
+
+        Returns:
+            dict[str, MainTypes]: A dictionary containing the components of the Workflow
+                definition, for use in Snakemake workflows.
+        """
+        return {
+            f"rule {step.name.replace('-', '_')}": step.render() for step in self.steps
+        }
+
+
+def raw_render(workflow: Workflow) -> dict[str, MainTypes]:
+    """Render the workflow as a Snakemake (SMK) string.
+
+    This function converts a Workflow object into a object containing snakemake rules.
+
+    Args:
+        workflow (Workflow): The workflow to be rendered.
+
+    Returns:
+        dict[str, MainTypes]: A dictionary containing the components of the Workflow
+            definition, for use in Snakemake workflows.
+    """
+    return WorkflowDefinition.from_workflow(workflow).render()
+
+
+def render(workflow: Workflow) -> str:
+    """Render the workflow as a Snakemake (SMK) string.
+
+    This function converts a Workflow object into a Snakemake-compatible yaml.
+
+    Args:
+        workflow (Workflow): The workflow to be rendered.
+
+    Returns:
+        str: A Snakemake-compatible yaml representation of the workflow.
+    """
+    trans_table = str.maketrans(
+        {
+            "-": "   ",
+            "'": "",
+            "[": "",
+            "]": "",
+        }
+    )
+
+    return yaml.dump(
+        WorkflowDefinition.from_workflow(workflow).render(), indent=4
+    ).translate(trans_table)


### PR DESCRIPTION
### Summary

This Pull Request adds a custom snakemake renderer that produces a workflow in snakemake. This will be an example renderer for a tutorial on how to create a custom renderer in dewret. The renderer is tested with most of snakemakes quirks to produce a workflow with minimal tweaks to be executable. I've added # TODOs inside the renderer for possible features which I will also list here

### Changes

- Added `SnakemakeRenderer` class to `examples` as it needs approval - if approved I can move it to renderers dewrete.renderers.
- Split each snakemake rule into separated blocks in:
    - InputDefinition: Which contains the input and parameters blocks. I've combined the params and input blocks into InputDefinition to eliminate redundancy. The input block in Snakemake specifies the required input files for a rule to run, while the params block defines the actual arguments for the rule. Both blocks required similar processing, so merging them seemed more efficient.
    - OutputDefinition: Which defines the output block of snakemake - Output block defines what files need to exist in order for the rule to be considered finished.
    - RunDefinition: Which defines the run block of snakemake - Run block defines what processes are needed to run (e.g. dewret Tasks).
- Added and example using the snakemake renderer.

### Motivation

To be used as an example custom renderer for a tutorial on how custom renderers are created. The Snakemake language is widely used in the bioinformatics community for creating reproducible and scalable workflows so the snakemake renderer was a good choice for both usability and an example.

### Possible improvements

- Feature: add a rule all: In snakemake if you want to run multiple connected rules you have a rule all with the input definition being the last task's output to make sure all of the rules run.
- Feature: add tests.
- Refactor: better way to handle the types. `to_snakemake_type` methods conversion of types could be imrpoved.
- Refactor: introduce better error handling.
- Refactor: better way to handle input/output files.
### Issues
- pre-commit hooks don't take into account my local environment and show a variety of unfixable errors.
- task() annotations of a workflow must be removed before executing snakemake generated workflow. 
### Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added docstrings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have linted, formated and mypy checked my code as per project requirements.
- [ ] I have written tests.