### PR TITLE
Feat/33 documentation tidy up

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,13 +1,13 @@
 # Glossary
 
 #### Construct
-- An alias pointing to an instance of the TaskManager class, used for constructing a set of [tasks](#task) into a dewret workflow instance.
+- To `construct` a workflow in dewret is to pull the connected steps into a single structure.
 
 #### Nested Task
 - Specific type of [task](#task) designed to encapsulate multiple tasks. Nested tasks are the culmination (or result) of multiple tasks represented as a single task in a dewret [workflow](#workflow).
 
 #### Render
-- Render is a renderer-specific method that generates a workflow structure in the specific workflow language. Current defaults are CWL and Snakemake. 
+- To render a workflow is to generate an executable workflow in a specific workflow language such as and Snakemake. 
 
 #### Step
 - A step in a dewret workflow represents a single unit of work. It contains a single task and the arguments for that task. Corresponds to a CWL [Step](https://www.commonwl.org/user_guide/topics/workflows.html#workflows) or a Snakemake [Rule](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html)
@@ -16,4 +16,4 @@
 - A task is the function scheduled to be executed later. Corresponds to a CWL [Process](https://www.commonwl.org/user_guide/introduction/basic-concepts.html#processes-and-requirements)
 
 #### Workflow
-- A workflow is designed to define, manage, and execute a series of tasks (or steps) that make use of both local and global parameters.
+- A workflow is designed to define, manage, and execute a series of tasks that make use of both local and global parameters.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -9,7 +9,7 @@
 - Specific type of [task](#task) designed to encapsulate multiple tasks. Nested tasks are the culmination (or result) of multiple tasks represented as a single task in a dewret [workflow](#workflow).
 
 #### Render
-- To render a workflow is to generate an executable workflow in a specific workflow language such as and Snakemake. 
+- To render a workflow is to generate an executable workflow in a specific workflow language such as CWL and Snakemake. 
 
 #### Step
 - A step in a dewret workflow represents a single unit of work. It contains a single task and the arguments for that task. Corresponds to a CWL [Step](https://www.commonwl.org/user_guide/topics/workflows.html#workflows) or a Snakemake [Rule](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -3,7 +3,9 @@
 #### Construct
 - To `construct` a workflow in dewret is to pull the connected steps into a single structure.
 
-#### Nested Task
+#### Sub Workflow
+- A subworkflow is a nested or hierarchical workflow. It is a workflow defined within another workflow, allowing for the encapsulation and reuse of complex operations as a single, higher-level step in the parent workflow.
+
 - Specific type of [task](#task) designed to encapsulate multiple tasks. Nested tasks are the culmination (or result) of multiple tasks represented as a single task in a dewret [workflow](#workflow).
 
 #### Render

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,10 +15,10 @@ Workflows are a collection of tasks or steps designed to automate complex proces
 Dewret stands out by providing a unified and simplified interface for workflow management, making it accessible to users with varying levels of experience. Here are some key features that make Dewret unique:
 - Consistency: offers a consistent interface for defining tasks and workflows.
 - Optimization: creating a declarative workflow opens up possibilities for static analysis and refactoring before execution.
-- Customization: ability to create a custom renderer in a desired workflow language.
-- Git-versionable workflows: while code can be versioned, the changes of a dynamic workflow do not necessarily clearly correspond to changes in the executed workflow. This maintains a precise trackable history.
+- Customization: dewret offers the ability to create custom renderers for workflows in desired languages. This includes default support for CWL and Snakemake workflow languages. The capability to render a single workflow into multiple declarative languages enables users to experiment with different workflow engines.
+- Git-versionable workflows: while code can be versioned, changes in a dynamic workflow may not clearly correspond to changes in the executed workflow. By defining a static workflow that is rendered from the dynamic or programmatic workflow, we maintain a precise and trackable history.
 - Default Renderers: Snakemake and CWL.
-- Debugging: a number of classes of workflow planning bugs will not appear until late in a simulation run that might take days or weeks. This catches them before startup.
+- Debugging: a number of classes of workflow planning bugs will not appear until late in a simulation run that might take days or weeks. Having a declarative and static workflow definition document post-render provides enhanced possibilities for static analysis, helping to catch these issues before startup.
 - Continuous Integration and Testing: complex dynamic workflows can be rapidly sense-checked in CI without needing all the hardware and internal algorithms present to run them.
 
 ## Installation for pure users

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@
 
 ### Description 
 
-Dewret is a tool designed for creating complex workflows, written in a dynamic style, to be rendered to a static representation. It makes it easier for users to define tasks and organize them into workflows. Currently, Dewret supports two renderers: Snakemake and CWL, which generate yamls in the corresponding workflow languages.
+Dewret is a tool designed for creating complex workflows, written in a dynamic style, to be rendered to a static representation. Dewret provides a programmatic python interface to multiple declarative workflow engines, where workflows are often written in a yaml-like syntax. It makes it easier for users to define tasks and organize them into workflows. Currently, Dewret supports two renderers: Snakemake and CWL, which generate yamls in the corresponding workflow languages.
 
 ### What are Workflows?
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,24 +4,24 @@
 
 ### Description 
 
-Dewret is a tool designed for creating complex workflows, written in a dynamic style, to be rendered to a static representation. It makes it easier for users to define tasks and organize them into workflows. Dewret works closely with Dask, providing a programmatic python interface to multiple declarative workflow engines, where workflows are often written in a yaml-like syntax. Currently, Dewret supports two renderers: Snakemake and CWL, which generate workflows in the corresponding workflow languages.
+Dewret is a tool designed for creating complex workflows, written in a dynamic style, to be rendered to a static representation. It makes it easier for users to define tasks and organize them into workflows. Currently, Dewret supports two renderers: Snakemake and CWL, which generate yamls in the corresponding workflow languages.
 
 ### What are Workflows?
 
-Workflows are a collection of tasks or steps designed to automate complex processes. These processes are common in fields like data science and software development, where you can ensure automation. Traditionally, managing workflows can be challenging due to the diversity of backend systems and the complexity of configurations involved.
+Workflows are a collection of tasks or steps designed to automate complex processes. These processes are common in fields like data science, scientific computing and software development, where you can ensure automation. Traditionally, managing workflows can be challenging due to the diversity of backend systems and the complexity of configurations involved.
 
 ### What Makes Dewret Unique? Why should I use Dewret?
 
 Dewret stands out by providing a unified and simplified interface for workflow management, making it accessible to users with varying levels of experience. Here are some key features that make Dewret unique:
 - Consistency: offers a consistent interface for defining tasks and workflows.
-- Optimization: creating the workflow explicitly opens up possibilities for static analysis and refactoring before real execution.
-- Customization: ability to create custom renderers in the required workflow language.
+- Optimization: creating a declarative workflow opens up possibilities for static analysis and refactoring before execution.
+- Customization: ability to create a custom renderer in a desired workflow language.
 - Git-versionable workflows: while code can be versioned, the changes of a dynamic workflow do not necessarily clearly correspond to changes in the executed workflow. This maintains a precise trackable history.
 - Default Renderers: Snakemake and CWL.
 - Debugging: a number of classes of workflow planning bugs will not appear until late in a simulation run that might take days or weeks. This catches them before startup.
 - Continuous Integration and Testing: complex dynamic workflows can be rapidly sense-checked in CI without needing all the hardware and internal algorithms present to run them.
 
-## Instalation for pure users
+## Installation for pure users
 
 If you simply want to use Dewret to run workflows, you can install it from PyPI or Conda.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,41 @@
 # Quickstart
 
-## Installation
+## Introduction 
+
+### Description 
+
+Dewret is a tool designed for creating complex workflows, written in a dynamic style, to be rendered to a static representation. It makes it easier for users to define tasks and organize them into workflows. Dewret works closely with Dask, providing a programmatic python interface to multiple declarative workflow engines, where workflows are often written in a yaml-like syntax. Currently, Dewret supports two renderers: Snakemake and CWL, which generate workflows in the corresponding workflow languages.
+
+### What are Workflows?
+
+Workflows are a collection of tasks or steps designed to automate complex processes. These processes are common in fields like data science and software development, where you can ensure automation. Traditionally, managing workflows can be challenging due to the diversity of backend systems and the complexity of configurations involved.
+
+### What Makes Dewret Unique? Why should I use Dewret?
+
+Dewret stands out by providing a unified and simplified interface for workflow management, making it accessible to users with varying levels of experience. Here are some key features that make Dewret unique:
+- Consistency: offers a consistent interface for defining tasks and workflows.
+- Optimization: creating the workflow explicitly opens up possibilities for static analysis and refactoring before real execution.
+- Customization: ability to create custom renderers in the required workflow language.
+- Git-versionable workflows: while code can be versioned, the changes of a dynamic workflow do not necessarily clearly correspond to changes in the executed workflow. This maintains a precise trackable history.
+- Default Renderers: Snakemake and CWL.
+- Debugging: a number of classes of workflow planning bugs will not appear until late in a simulation run that might take days or weeks. This catches them before startup.
+- Continuous Integration and Testing: complex dynamic workflows can be rapidly sense-checked in CI without needing all the hardware and internal algorithms present to run them.
+
+## Instalation for pure users
+
+If you simply want to use Dewret to run workflows, you can install it from PyPI or Conda.
+
+### From PyPI:
+```shell
+pip install dewret
+```
+
+### From Conda:
+```shell
+conda install conda-forge::dewret
+```
+
+## Installation for developers
 
 From a cloned repository:
 

--- a/src/dewret/tasks.py
+++ b/src/dewret/tasks.py
@@ -211,6 +211,9 @@ ensure_lazy = _manager.ensure_lazy
 unwrap = _manager.unwrap
 evaluate = _manager.evaluate
 construct = _manager
+"""An alias pointing to an instance of the TaskManager class.
+Used for constructing a set of tasks into a dewret workflow instance.
+"""
 
 
 class TaskException(Exception):


### PR DESCRIPTION
## Summary

This PR improves the Quickstart.md documentation for Dewret as discussed in [issue #33](https://github.com/flaxandteal/dewret/issues/33). The update creates an introduction to Dewret and attempts to answer the question Why use Dewret?

## Changes
- Introduction: Added a detailed description of Dewret, highlighting its purpose, features, and supported renderers (Snakemake and CWL).
- What are Workflows?: Explained the concept of workflows.
- Highlighted Dewret's unique features.
- Installation for Pure Users