### PR TITLE
Fix/31 return tuple

### DIFF
--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -22,7 +22,7 @@ from attrs import define, has as attrs_has, fields as attrs_fields, AttrsInstanc
 from dataclasses import dataclass, is_dataclass, fields as dataclass_fields
 from collections.abc import Mapping
 from contextvars import ContextVar
-from typing import TypedDict, NotRequired, get_args, Union, cast, Any, Unpack
+from typing import TypedDict, NotRequired, get_args, Union, cast, Any, Iterable, Unpack
 from types import UnionType
 
 from dewret.workflow import (
@@ -210,12 +210,14 @@ def to_cwl_type(typ: type) -> str | list[str]:
         return "boolean"
     elif typ == dict or attrs_has(typ):
         return "record"
-    elif typ == list:
-        return "array"
     elif typ == float:
         return "double"
     elif typ == str:
         return "string"
+    elif typ == bytes:
+        return "bytes"
+    elif isinstance(typ, Iterable):
+        return "array"
     else:
         if configuration("allow_complex_types"):
             return typ if isinstance(typ, str) else typ.__name__

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -226,7 +226,7 @@ def to_cwl_type(typ: type) -> str | dict[str, Any] | list[str]:
             if len(basic_types) > 1:
                 return {
                     "type": "array",
-                    "items": [to_cwl_type(t) for t in get_args(typ)],
+                    "items": [{"type": to_cwl_type(t)} for t in basic_types],
                 }
             else:
                 return {"type": "array", "items": to_cwl_type(basic_types[0])}

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -218,10 +218,10 @@ def to_cwl_type(typ: type) -> str | dict[str, Any] | list[str]:
         return "string"
     elif typ == bytes:
         return "bytes"
-    else:
-        if configuration("allow_complex_types"):
-            return typ if isinstance(typ, str) else typ.__name__
-        elif isinstance(typ, Iterable):
+    elif configuration("allow_complex_types"):
+        return typ if isinstance(typ, str) else typ.__name__
+    elif isinstance(typ, Iterable):
+        try:
             basic_types = get_args(typ)
             if len(basic_types) > 1:
                 return {
@@ -230,6 +230,11 @@ def to_cwl_type(typ: type) -> str | dict[str, Any] | list[str]:
                 }
             else:
                 return {"type": "array", "items": to_cwl_type(basic_types[0])}
+        except IndexError as err:
+            raise TypeError(
+                f"Cannot render complex type ({typ}) to CWL, have you enabled allow_complex_types configuration?"
+            ) from err
+    else:
         raise TypeError(f"Cannot render complex type ({typ}) to CWL")
 
 

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -203,9 +203,6 @@ def to_cwl_type(typ: type) -> str | dict[str, Any] | list[str]:
         CWL specification type name, or a list
         if a union.
     """
-    if isinstance(typ, UnionType):
-        return [to_cwl_type(item) for item in get_args(typ)]
-
     if typ == int:
         return "int"
     elif typ == bool:
@@ -220,6 +217,8 @@ def to_cwl_type(typ: type) -> str | dict[str, Any] | list[str]:
         return "bytes"
     elif configuration("allow_complex_types"):
         return typ if isinstance(typ, str) else typ.__name__
+    elif isinstance(typ, UnionType):
+        return [to_cwl_type(item) for item in get_args(typ)]
     elif isinstance(typ, Iterable):
         try:
             basic_types = get_args(typ)

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -465,7 +465,7 @@ class Workflow:
         new.tasks.update(right.tasks)
 
         for step in new.steps:
-            step.__workflow__ = new
+            step.set_workflow(new, False)
 
         # TODO: should we combine as a result array?
         result = left.result or right.result
@@ -742,7 +742,7 @@ class BaseStep(WorkflowComponent):
             and self.arguments == other.arguments
         )
 
-    def set_workflow(self, workflow: Workflow) -> None:
+    def set_workflow(self, workflow: Workflow, without_arguments: bool = False) -> None:
         """Move the step reference to another workflow.
 
         Primarily intended to be called by its step, as a cascade.
@@ -750,14 +750,16 @@ class BaseStep(WorkflowComponent):
 
         Args:
             workflow: the new target workflow.
+            without_arguments: do not set workflows for the arguments.
         """
         self.__workflow__ = workflow
-        for argument in self.arguments.values():
-            if hasattr(argument, "__workflow__"):
-                try:
-                    argument.__workflow__ = workflow
-                except AttributeError:
-                    ...
+        if not without_arguments:
+            for argument in self.arguments.values():
+                if hasattr(argument, "__workflow__"):
+                    try:
+                        argument.__workflow__ = workflow
+                    except AttributeError:
+                        ...
 
     @property
     def return_type(self) -> Any:
@@ -1011,6 +1013,7 @@ class StepReference(Generic[U], Reference):
     """
 
     step: BaseStep
+    _tethered_workflow: Workflow | None
     _field: str | None
     typ: type[U]
 
@@ -1039,6 +1042,7 @@ class StepReference(Generic[U], Reference):
         self.step = step
         self._field = field
         self.typ = typ
+        self._tethered_workflow = None
 
     def __str__(self) -> str:
         """Global description of the reference."""
@@ -1119,7 +1123,24 @@ class StepReference(Generic[U], Reference):
         Returns:
             Workflow that the referee is related to.
         """
-        return self.step.__workflow__
+        return self._tethered_workflow or self.step.__workflow__
+
+    @__workflow__.setter
+    def __workflow__(self, workflow: Workflow) -> None:
+        """Sets related workflow.
+
+        We update the tethered workflow. If the step is missing from
+        this workflow then, by construction, it should have at least
+        been through an indexing process once, so we should be able
+        to get it back by name.
+
+        Args:
+            workflow: workflow to update the step
+        """
+        self._tethered_workflow = workflow
+        if self._tethered_workflow:
+            if self.step not in self._tethered_workflow.steps:
+                self.step = self._tethered_workflow._indexed_steps[self.step.id]
 
     @__workflow__.setter
     def __workflow__(self, workflow: Workflow) -> None:

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -743,14 +743,15 @@ class BaseStep(WorkflowComponent):
         )
 
     def set_workflow(self, workflow: Workflow, with_arguments: bool = True) -> None:
-        """Move the step reference to another workflow.
+        """Move the step reference to a different workflow.
 
-        Primarily intended to be called by its step, as a cascade.
-        It will attempt to update its arguments, similarly.
+        This method is primarily intended to be called by a step, allowing it to
+        switch to a new workflow. It also updates the workflow reference for any
+        arguments that are steps themselves, if specified.
 
         Args:
-            workflow: the new target workflow.
-            with_arguments: set workflows for the arguments..
+            workflow: The new target workflow to which the step should be moved.
+            with_arguments: If True, also update the workflow reference for the step's arguments.
         """
         self.__workflow__ = workflow
         if with_arguments:
@@ -1052,7 +1053,7 @@ class StepReference(Generic[U], Reference):
         """Hashable reference to the step (and field)."""
         return f"{self.step.id}/{self.field}"
 
-    def __getattr__(self, attr: str) -> "StepReference"[Any]:
+    def __getattr__(self, attr: str) -> "StepReference[Any]":
         """Reference to a field within this result, if possible.
 
         If the result is an attrs-class or dataclass, this will pull out an individual

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# with WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
@@ -465,7 +465,7 @@ class Workflow:
         new.tasks.update(right.tasks)
 
         for step in new.steps:
-            step.set_workflow(new, False)
+            step.set_workflow(new, with_arguments=True)
 
         # TODO: should we combine as a result array?
         result = left.result or right.result
@@ -742,7 +742,7 @@ class BaseStep(WorkflowComponent):
             and self.arguments == other.arguments
         )
 
-    def set_workflow(self, workflow: Workflow, without_arguments: bool = False) -> None:
+    def set_workflow(self, workflow: Workflow, with_arguments: bool = True) -> None:
         """Move the step reference to another workflow.
 
         Primarily intended to be called by its step, as a cascade.
@@ -750,10 +750,10 @@ class BaseStep(WorkflowComponent):
 
         Args:
             workflow: the new target workflow.
-            without_arguments: do not set workflows for the arguments.
+            with_arguments: set workflows for the arguments..
         """
         self.__workflow__ = workflow
-        if not without_arguments:
+        if with_arguments:
             for argument in self.arguments.values():
                 if hasattr(argument, "__workflow__"):
                     try:

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -37,3 +37,9 @@ def sum(left: int | float, right: int | float) -> int | float:
 def triple_and_one(num: int | float) -> int | float:
     """Triple a number by doubling and adding again, then add 1."""
     return sum(left=sum(left=double(num=num), right=num), right=1)
+
+
+@task()
+def tuple_float_return() -> tuple[float, float]:
+    """Return a tuple of floats."""
+    return 48.856667, 2.351667

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -23,7 +23,7 @@ def double(num: int | float) -> int | float:
 
 @task()
 def mod10(num: int) -> int:
-    """Double an integer."""
+    """Remainder of an integer divided by 10."""
     return num % 10
 
 

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -7,7 +7,14 @@ from dewret.renderers.cwl import render
 from dewret.utils import hasher
 from dewret.workflow import param
 
-from ._lib.extra import increment, double, mod10, sum, triple_and_one
+from ._lib.extra import (
+    increment,
+    double,
+    mod10,
+    sum,
+    triple_and_one,
+    tuple_float_return,
+)
 
 
 @task()
@@ -328,7 +335,9 @@ def test_cwl_references() -> None:
           out:
             label: out
             outputSource: double-{hsh_double}/out
-            type: [int, double]
+            type: 
+            - int
+            - double
         steps:
           increment-{hsh_increment}:
             run: increment
@@ -370,7 +379,9 @@ def test_complex_cwl_references() -> None:
           out:
             label: out
             outputSource: sum-1/out
-            type: [int, double]
+            type: 
+            - int
+            - double
         steps:
           increment-1:
             run: increment
@@ -510,4 +521,35 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
             out:
             - out
             run: sum
+    """)
+
+
+def test_tuple_floats() -> None:
+    """Check whether we can link between multiple steps.
+
+    Produces CWL that has references between multiple steps.
+    """
+    result = tuple_float_return()
+    workflow = construct(result, simplify_ids=True)
+    rendered = render(workflow)
+
+    assert rendered == yaml.safe_load("""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs: {}
+        outputs:
+          out:
+            label: out
+            outputSource: tuple_float_return-1/out
+            type: 
+              items: [
+                float,
+                float
+              ]
+              type: array
+        steps:
+          tuple_float_return-1:
+            run: tuple_float_return
+            in: {}
+            out: [out]
     """)

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -525,9 +525,9 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
 
 
 def test_tuple_floats() -> None:
-    """Check whether we can link between multiple steps.
+    """Checks whether we can return a tuple.
 
-    Produces CWL that has references between multiple steps.
+    Produces CWL that has a tuple of 2 values of type float.
     """
     result = tuple_float_return()
     workflow = construct(result, simplify_ids=True)

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -61,7 +61,7 @@ def test_basic_cwl() -> None:
           out:
             label: out
             outputSource: pi-{hsh}/out
-            type: double
+            type: float
         steps:
           pi-{hsh}:
             run: pi
@@ -279,7 +279,7 @@ def test_cwl_with_subworkflow() -> None:
             outputSource: sum-1-2/out
             type:
             - int
-            - double
+            - float
         steps:
           double-1-1:
             in:
@@ -337,7 +337,7 @@ def test_cwl_references() -> None:
             outputSource: double-{hsh_double}/out
             type: 
             - int
-            - double
+            - float
         steps:
           increment-{hsh_increment}:
             run: increment
@@ -381,7 +381,7 @@ def test_complex_cwl_references() -> None:
             outputSource: sum-1/out
             type: 
             - int
-            - double
+            - float
         steps:
           increment-1:
             run: increment
@@ -482,7 +482,7 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
             label: num
             type: [
               int,
-              double
+              float
             ]
           sum-1-2-right:
             default: 1
@@ -494,7 +494,7 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
             outputSource: sum-1-2/out
             type:
             - int
-            - double
+            - float
         steps:
           double-1-1:
             in:
@@ -542,10 +542,9 @@ def test_tuple_floats() -> None:
             label: out
             outputSource: tuple_float_return-1/out
             type: 
-              items: [
-                float,
-                float
-              ]
+              items: 
+                - float
+                - float
               type: array
         steps:
           tuple_float_return-1:

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -532,7 +532,7 @@ def test_tuple_floats() -> None:
     result = tuple_float_return()
     workflow = construct(result, simplify_ids=True)
     rendered = render(workflow)
-
+    print(yaml.dump(rendered))
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
         class: Workflow
@@ -543,8 +543,8 @@ def test_tuple_floats() -> None:
             outputSource: tuple_float_return-1/out
             type: 
               items: 
-                - float
-                - float
+                - type: float
+                - type: float
               type: array
         steps:
           tuple_float_return-1:

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -31,7 +31,7 @@ def test_nested_task() -> None:
         inputs:
           JUMP:
             label: JUMP
-            type: double
+            type: float
             default: 1.0
           increase-3-num:
             default: 23
@@ -45,7 +45,7 @@ def test_nested_task() -> None:
           out:
             label: out
             outputSource: sum-1/out
-            type: [int, double]
+            type: [int, float]
         steps:
           increase-1:
             run: increase

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -258,8 +258,8 @@ def test_pair_can_be_returned_from_step() -> None:
             outputSource: pair-1/out
             type: 
               items: 
-                - float
-                - float
+                - type: float
+                - type: float
               type: array
         steps:
           pair-1:

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -99,7 +99,7 @@ def test_nested_task() -> None:
                     type: int
                 second:
                     label: second
-                    type: double
+                    type: float
         steps:
           split-1:
             in: {}
@@ -109,7 +109,7 @@ def test_nested_task() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float
             run: split
     """)
 
@@ -137,7 +137,7 @@ def test_field_of_nested_task() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float
             run: split
     """)
 
@@ -165,7 +165,7 @@ def test_field_of_nested_task_into_dataclasses() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float
             run: split_into_dataclass
     """)
 
@@ -183,7 +183,7 @@ def test_complex_field_of_nested_task() -> None:
           out:
             label: out
             outputSource: combine-1/out
-            type: double
+            type: float
         steps:
           combine-1:
             in:
@@ -201,7 +201,7 @@ def test_complex_field_of_nested_task() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float
             run: split
     """)
 
@@ -220,7 +220,7 @@ def test_complex_field_of_nested_task_with_dataclasses() -> None:
           out:
             label: out
             outputSource: combine-1/out
-            type: double
+            type: float
         steps:
           combine-1:
             in:
@@ -238,7 +238,7 @@ def test_complex_field_of_nested_task_with_dataclasses() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float
             run: split_into_dataclass
     """)
 
@@ -257,10 +257,9 @@ def test_pair_can_be_returned_from_step() -> None:
             label: out
             outputSource: pair-1/out
             type: 
-              items: [
-                float,
-                float,
-              ]
+              items: 
+                - float
+                - float
               type: array
         steps:
           pair-1:
@@ -279,7 +278,7 @@ def test_pair_can_be_returned_from_step() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float 
             run: split_into_dataclass
     """)
 
@@ -323,6 +322,6 @@ def test_list_can_be_returned_from_step() -> None:
                 type: int
               second:
                 label: second
-                type: double
+                type: float
             run: split_into_dataclass
     """)

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -256,7 +256,12 @@ def test_pair_can_be_returned_from_step() -> None:
           out:
             label: out
             outputSource: pair-1/out
-            type: array
+            type: 
+              items: [
+                float,
+                float,
+              ]
+              type: array
         steps:
           pair-1:
             in:
@@ -292,7 +297,9 @@ def test_list_can_be_returned_from_step() -> None:
           out:
             label: out
             outputSource: list_cast-1/out
-            type: array
+            type:
+              items: float
+              type: array
         steps:
           list_cast-1:
             in:

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -34,13 +34,13 @@ def combine(left: int, right: float) -> float:
 
 @task()
 def list_cast(iterable: Iterable[float]) -> list[float]:
-    """Sum two values."""
+    """Converts an iterable structure with float elements into a list of floats."""
     return list(iterable)
 
 
 @task()
-def pair(left: int, right: float) -> tuple[float, float]:
-    """Sum two values."""
+def pair(left: int, right: float) -> tuple[int, float]:
+    """Pairs two values."""
     return (left, right)
 
 
@@ -51,14 +51,14 @@ def algorithm() -> float:
 
 
 @nested_task()
-def algorithm_with_pair() -> tuple[float, float]:
-    """Sum two split values."""
+def algorithm_with_pair() -> tuple[int, float]:
+    """Pairs two split dataclass values."""
     return pair(left=split_into_dataclass().first, right=split_into_dataclass().second)
 
 
 @nested_task()
 def algorithm_with_dataclasses() -> float:
-    """Sum two split values."""
+    """Sums two split dataclass values."""
     return combine(
         left=split_into_dataclass().first, right=split_into_dataclass().second
     )
@@ -66,7 +66,7 @@ def algorithm_with_dataclasses() -> float:
 
 @task()
 def split() -> SplitResult:
-    """Create a result with two fields."""
+    """Create a split result with two fields."""
     return SplitResult(first=1, second=2)
 
 
@@ -171,7 +171,7 @@ def test_field_of_nested_task_into_dataclasses() -> None:
 
 
 def test_complex_field_of_nested_task() -> None:
-    """Tests whether a task can insert result fields into other steps."""
+    """Tests whether a task can sum complex structures."""
     workflow = construct(algorithm(), simplify_ids=True)
     rendered = render(workflow)
 
@@ -258,7 +258,7 @@ def test_pair_can_be_returned_from_step() -> None:
             outputSource: pair-1/out
             type: 
               items: 
-                - type: float
+                - type: int
                 - type: float
               type: array
         steps:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -63,7 +63,6 @@ def test_complex_parameters() -> None:
     result = sum(left=double(num=rotate(num=num)), right=rotate(num=rotate(num=23)))
     workflow = construct(result, simplify_ids=True)
     rendered = render(workflow)
-
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
         class: Workflow

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -83,7 +83,7 @@ def test_complex_parameters() -> None:
           out:
             label: out
             outputSource: sum-1/out
-            type: [int, double]
+            type: [int, float]
         steps:
           rotate-1:
             run: rotate


### PR DESCRIPTION
# Summary
This PR enhances the tuple[float, float] support in Dewret, initial implementation issues encountered during testing.

# Changes

- Introduced tuple[float, float] support to Dewret.
- Encountered unforeseen errors during test implementation.

# Issues
1. Still need to fix conflicts with [base branch](https://github.com/flaxandteal/dewret/tree/release/0.9.1)
2. Comments are left in [renderers/cwl.py,](https://github.com/flaxandteal/dewret/compare/release/0.9.1...fix/31-return-tuple?expand=1#diff-b8b249578c75f313e741bc40595b2faff3623708f89e0a250745da994e3c5a7dR154) 
code on [line 140](https://github.com/flaxandteal/dewret/compare/release/0.9.1...fix/31-return-tuple?expand=1#diff-b8b249578c75f313e741bc40595b2faff3623708f89e0a250745da994e3c5a7dR140) no longer returns for example 
```yaml
[int, double]
```
but returns:
```yaml
- int
- double
```
for some unknown reason. This method of creating an array does not cause any issues with the CWL format.