### PR TITLE
Added a wrapper class for renderers for testing purposes

### DIFF
--- a/src/dewret/core.py
+++ b/src/dewret/core.py
@@ -38,7 +38,7 @@ from typing import (
     Annotated,
     Callable,
     cast,
-    runtime_checkable,
+    runtime_checkable
 )
 from contextlib import contextmanager
 from contextvars import ContextVar

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -56,7 +56,12 @@ from dewret.utils import (
     Unset,
 )
 from dewret.render import base_render
-from dewret.core import Reference, get_render_configuration, set_render_configuration
+from dewret.core import (
+    Reference,
+    get_render_configuration,
+    set_render_configuration,
+    StructuredRenderModule,
+)
 
 
 class CommandInputSchema(TypedDict):
@@ -744,23 +749,25 @@ class WorkflowDefinition:
         }
 
 
-def render(
-    workflow: Workflow, **kwargs: Unpack[CWLRendererConfiguration]
-) -> dict[str, dict[str, RawType]]:
-    """Render to a dict-like structure.
+class Renderer(StructuredRenderModule):
+    """Wrapper class implementing StructuredRenderModule protocol."""
+    def render(
+        workflow: Workflow, **kwargs: Unpack[CWLRendererConfiguration]
+    ) -> dict[str, dict[str, RawType]]:
+        """Render to a dict-like structure.
 
-    Args:
-        workflow: workflow to evaluate result.
-        **kwargs: additional configuration arguments - these should match CWLRendererConfiguration.
+        Args:
+            workflow: workflow to evaluate result.
+            **kwargs: additional configuration arguments - these should match CWLRendererConfiguration.
 
-    Returns:
-        Reduced form as a native Python dict structure for
-        serialization.
-    """
-    # TODO: Again, convincing mypy that a TypedDict has RawType values.
-    with set_render_configuration(kwargs):  # type: ignore
-        rendered = base_render(
-            workflow,
-            lambda workflow: WorkflowDefinition.from_workflow(workflow).render(),
-        )
-    return rendered
+        Returns:
+            Reduced form as a native Python dict structure for
+            serialization.
+        """
+        # TODO: Again, convincing mypy that a TypedDict has RawType values.
+        with set_render_configuration(kwargs):  # type: ignore
+            rendered = base_render(
+                workflow,
+                lambda workflow: WorkflowDefinition.from_workflow(workflow).render(),
+            )
+        return rendered

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from dewret.tasks import construct, workflow, TaskException
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 from dewret.annotations import AtRender, FunctionAnalyser, Fixed
 from dewret.core import set_configuration
 
@@ -82,7 +82,7 @@ def test_at_render() -> None:
 
     result = to_int(num=increment(num=3), should_double=True)
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -120,7 +120,7 @@ def test_at_render() -> None:
 
     result = to_int(num=increment(num=3), should_double=False)
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -161,7 +161,7 @@ def test_at_render_between_modules() -> None:
     """Test rendering of workflows across different modules using `dewret.annotations.AtRender`."""
     result = try_nothing()
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     subworkflows["__root__"]
 
 
@@ -181,7 +181,7 @@ def test_can_loop_over_fixed_length() -> None:
     with set_configuration(flatten_all_nested=True):
         result = loop_over_lists(list_1=[5, 6, 7, 8])
         wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
     assert rendered == yaml.safe_load("""
         class: Workflow

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,7 +3,7 @@
 import yaml
 import pytest
 from dewret.tasks import construct, workflow, TaskException
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 from dewret.core import set_configuration
 from dewret.annotations import AtRender
 from ._lib.extra import increment
@@ -38,7 +38,7 @@ def test_cwl_with_parameter() -> None:
     with set_configuration(flatten_all_nested=True):
         result = increment(num=floor(num=3, expected=True))
         workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
     num_param = list(workflow.find_parameters())[0]
     assert num_param
 

--- a/tests/test_fieldable.py
+++ b/tests/test_fieldable.py
@@ -9,7 +9,7 @@ from typing import Unpack, TypedDict
 from dewret.tasks import task, construct, workflow
 from dewret.core import set_configuration
 from dewret.workflow import param, StepReference
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 from dewret.annotations import Fixed
 
 from ._lib.extra import mod10, sum, pi
@@ -36,7 +36,7 @@ def test_fields_of_parameters_usable() -> None:
     """Test that fields of parameters can be used to construct and render a workflow correctly."""
     result = sum_sides()
     wkflw = construct(result, simplify_ids=True)
-    rendered = render(wkflw, allow_complex_types=True)["sum_sides-1"]
+    rendered = Renderer.render(wkflw, allow_complex_types=True)["sum_sides-1"]
 
     assert rendered == yaml.safe_load("""
       class: Workflow
@@ -96,7 +96,7 @@ def test_can_get_field_reference_from_parameter() -> None:
     params = {(str(p), p.__type__) for p in wkflw.find_parameters()}
 
     assert params == {("my_param", MyDataclass)}
-    rendered = render(wkflw, allow_complex_types=True)["__root__"]
+    rendered = Renderer.render(wkflw, allow_complex_types=True)["__root__"]
     assert rendered == yaml.safe_load("""
         class: Workflow
         cwlVersion: 1.2
@@ -246,7 +246,7 @@ def test_can_iterate() -> None:
         result = test_iterated()
         wkflw = construct(result, simplify_ids=True)
 
-    rendered = render(wkflw, allow_complex_types=True)["__root__"]
+    rendered = Renderer.render(wkflw, allow_complex_types=True)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -317,7 +317,7 @@ def test_can_iterate() -> None:
         result = test_iterated_3(param=[(0, 1), (2, 3)])
         wkflw = construct(result, simplify_ids=True)
 
-    rendered = render(wkflw, allow_complex_types=True)["__root__"]
+    rendered = Renderer.render(wkflw, allow_complex_types=True)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -394,17 +394,17 @@ def test_can_configure_field_separator() -> None:
     with set_configuration(field_index_types="int"):
         result = test_sep().left[0]
         wkflw = construct(result, simplify_ids=True)
-        render(wkflw, allow_complex_types=True)["__root__"]
+        Renderer.render(wkflw, allow_complex_types=True)["__root__"]
         assert str(wkflw.result) == "test_sep-1/left[0]"
 
     with set_configuration(field_index_types="int,str"):
         result = test_sep().left[0]
         wkflw = construct(result, simplify_ids=True)
-        render(wkflw, allow_complex_types=True)["__root__"]
+        Renderer.render(wkflw, allow_complex_types=True)["__root__"]
         assert str(wkflw.result) == "test_sep-1[left][0]"
 
     with set_configuration(field_index_types=""):
         result = test_sep().left[0]
         wkflw = construct(result, simplify_ids=True)
-        render(wkflw, allow_complex_types=True)["__root__"]
+        Renderer.render(wkflw, allow_complex_types=True)["__root__"]
         assert str(wkflw.result) == "test_sep-1/left/0"

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -3,7 +3,7 @@
 import yaml
 from dewret.tasks import workflow, construct
 from dewret.core import set_configuration
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 from ._lib.extra import double, sum, increase
 
 STARTING_NUMBER: int = 23
@@ -25,7 +25,7 @@ def test_subworkflow() -> None:
     """
     with set_configuration(flatten_all_nested=True):
         workflow = construct(algorithm(), simplify_ids=True)
-        rendered = render(workflow)["__root__"]
+        rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable
 from dewret.tasks import task, construct, workflow
 from dewret.core import set_configuration
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 
 STARTING_NUMBER: int = 23
 
@@ -83,7 +83,7 @@ def test_subworkflow() -> None:
     Produces CWL that has references between multiple steps.
     """
     workflow = construct(split(), simplify_ids=True)
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -118,7 +118,7 @@ def test_subworkflow() -> None:
 def test_field_of_subworkflow() -> None:
     """Tests whether a directly-output nested task can have fields."""
     workflow = construct(split().first, simplify_ids=True)
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -146,7 +146,7 @@ def test_field_of_subworkflow() -> None:
 def test_field_of_subworkflow_into_dataclasses() -> None:
     """Tests whether a directly-output nested task can have fields."""
     workflow = construct(split_into_dataclass().first, simplify_ids=True)
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -175,7 +175,7 @@ def test_complex_field_of_subworkflow() -> None:
     """Tests whether a task can sum complex structures."""
     with set_configuration(flatten_all_nested=True):
         workflow = construct(algorithm(), simplify_ids=True)
-        rendered = render(workflow)["__root__"]
+        rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -213,7 +213,7 @@ def test_complex_field_of_subworkflow_with_dataclasses() -> None:
     with set_configuration(flatten_all_nested=True):
         result = algorithm_with_dataclasses()
         workflow = construct(result, simplify_ids=True)
-        rendered = render(workflow)["__root__"]
+        rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -250,7 +250,7 @@ def test_pair_can_be_returned_from_step() -> None:
     """Tests whether a task can insert result fields into other steps."""
     with set_configuration(flatten_all_nested=True):
         workflow = construct(algorithm_with_pair(), simplify_ids=True)
-        rendered = render(workflow)["__root__"]
+        rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -289,8 +289,10 @@ def test_pair_can_be_returned_from_step() -> None:
 def test_list_can_be_returned_from_step() -> None:
     """Tests whether a task can insert result fields into other steps."""
     with set_configuration(flatten_all_nested=True):
-        workflow = construct(list_cast(iterable=algorithm_with_pair()), simplify_ids=True)
-        rendered = render(workflow)["__root__"]
+        workflow = construct(
+            list_cast(iterable=algorithm_with_pair()), simplify_ids=True
+        )
+        rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -4,7 +4,7 @@ import yaml
 import math
 from dewret.workflow import param
 from dewret.tasks import construct
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 
 from ._lib.extra import reverse_list, max_list
 
@@ -21,7 +21,7 @@ def test_can_supply_nested_raw() -> None:
     # NB: This is not currently usefully renderable in CWL.
     # However, the structures are important for future CWL rendering.
 
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
     assert rendered == yaml.safe_load("""
         class: Workflow
         cwlVersion: 1.2

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -3,7 +3,7 @@
 import yaml
 from dewret.tasks import task, construct
 from dewret.workflow import param
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 
 from ._lib.extra import double, sum
 
@@ -23,7 +23,7 @@ def test_cwl_parameters() -> None:
     """
     result = rotate(num=3)
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -62,7 +62,7 @@ def test_complex_parameters() -> None:
     num = param("numx", 23)
     result = sum(left=double(num=rotate(num=num)), right=rotate(num=rotate(num=23)))
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)["__root__"]
+    rendered = Renderer.render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -5,7 +5,7 @@ from queue import Queue
 import yaml
 from dewret.tasks import construct, workflow, task, factory
 from dewret.core import set_configuration
-from dewret.renderers.cwl import render
+from dewret.renderers.cwl import Renderer
 from dewret.workflow import param
 from attrs import define
 
@@ -87,7 +87,7 @@ def test_cwl_for_pairs() -> None:
     with set_configuration(flatten_all_nested=True):
         result = pair_pi()
         wkflw = construct(result, simplify_ids=True)
-    rendered = render(wkflw)["__root__"]
+    rendered = Renderer.render(wkflw)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -118,7 +118,7 @@ def test_subworkflows_can_use_globals() -> None:
     my_param = param("num", typ=int)
     result = increment(num=add_constant(num=increment(num=my_param)))
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw)
+    subworkflows = Renderer.render(wkflw)
     rendered = subworkflows["__root__"]
 
     assert len(subworkflows) == 2
@@ -169,7 +169,7 @@ def test_subworkflows_can_use_factories() -> None:
     my_param = param("num", typ=int)
     result = pop(queue=make_queue(num=increment(num=my_param)))
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
 
     assert len(subworkflows) == 2
@@ -214,7 +214,7 @@ def test_subworkflows_can_use_global_factories() -> None:
     my_param = param("num", typ=int)
     result = pop(queue=get_global_queue(num=increment(num=my_param)))
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
 
     assert len(subworkflows) == 2
@@ -264,7 +264,7 @@ def test_subworkflows_can_return_lists() -> None:
     my_param = param("num", typ=int)
     result = get_global_queues(num=increment(num=my_param))
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
     del subworkflows["__root__"]
 
@@ -410,7 +410,7 @@ def test_can_merge_workflows() -> None:
     value = to_int(num=increment(num=my_param))
     result = sum(left=value, right=increment(num=value))
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows = Renderer.render(wkflw, allow_complex_types=True)
     rendered = subworkflows["__root__"]
     del subworkflows["__root__"]
 
@@ -464,7 +464,7 @@ def test_subworkflows_can_use_globals_in_right_scope() -> None:
     my_param = param("num", typ=int)
     result = increment(num=add_constants(num=increment(num=my_param)))
     wkflw = construct(result, simplify_ids=True)
-    subworkflows = render(wkflw)
+    subworkflows = Renderer.render(wkflw)
     rendered = subworkflows["__root__"]
     del subworkflows["__root__"]
 
@@ -583,7 +583,7 @@ def test_combining_attrs_and_factories() -> None:
 
     pack = Pack(hearts=13, spades=13, diamonds=13, clubs=13)
     wkflw = construct(black_total(pack=pack), simplify_ids=True)
-    cwl = render(wkflw, allow_complex_types=True, factories_as_params=True)
+    cwl = Renderer.render(wkflw, allow_complex_types=True, factories_as_params=True)
     assert cwl["__root__"] == yaml.safe_load("""
         class: Workflow
         cwlVersion: 1.2


### PR DESCRIPTION
## 🐛 Bug Fix

### Description

#### Root Cause:
I've tried testing the new implementation you've [incorporated.](https://github.com/flaxandteal/dewret/pull/55/files#diff-cb37f8e4a2cad74e0d3ff9719ecb3a859123320e8b94cd65e65d19ed8c67497dR94) 
After a load of research I don't think it's possible for an entire module to adhere to a interface protocol and especially won't hit the `isinstance()` method. 

I tried researching how exactly this was suppose to work thinking I've missed something but unfortunately I couldn't. 
Everywhere I read it said that it's not doable in python to make an entire model inherit or implement a protocol. 
I noticed that a class doesn't need to specifically inherit a protocol to be implementing it and considered part of it, but not for the whole model. 

During the research I asked Ellery to help me out because I thought I was missing something that could be found in the implementation of the internal Zomp renderer. Maybe a difference in how the renderer is build or sth. We made a discussion on how to proceed and we agreed that I should test some things out and then make a suggestion. 

During this I noticed that there isn't a specific case in this [code:](https://github.com/flaxandteal/dewret/pull/55/files#diff-946cfe0a788c575295a05596a5e4835cb5243959be5d9718c5b8e6be7b3ec370R81)

which handles the situation when the renderer has both methods implemented so it will default to the render_raw method due to this line here:
```python
    if isinstance(render_module, RawRenderModule):
        return render_module.render_raw
```
even though the user might have build both methods for some reason. That is if I've got something wrong during your implementation and you've figured out how to make an entire module implement a protocol. And for some reason it doesn't work for me or Ellery 

#### The suggestion
We could make a renderer wrapper class which will implement either RawRenderModule or StructuredRenderModule and create the corresponding method.

HardCode the name of the wrapper class like this: 

```python
    render_module: Path | ModuleType
    if (mtch := re.match(r"^([a-z_0-9-.]+)$", renderer)):
        render_module = importlib.import_module(f"dewret.renderers.{mtch.group(1)}")
        if not isinstance(render_module.Renderer, RawRenderModule) and not isinstance(render_module.Renderer, StructuredRenderModule):
            raise NotImplementedError("The imported render module does not seem to match the `RawRenderModule` or `StructuredRenderModule` protocols.")
```

or I figured that in order to implement it you had to import to import it when I `dir(render_module)` I saw the `StructuredRenderModule` as part of structure so something could be done from there for not hardcoding the wrapper class name.

and then pass that to the render module - `render = get_render_method(render_module.Renderer, pretty=pretty)`

And everything should work fine. 

### Changes Made

- Updated tests accordingly 
- Added a wrapper class implementing the given protocols
- Changed logic according to the wrapper class

### Additional Information

Add any other information, screenshots, or context that might help in understanding the feature request.

### Checklist

- [x] I have included a detailed description of the bugfix.
- [x] I have provided relevant documentation for my bugfix.
- [x] I have added the necessary tests.

### Who can review?

@philtweir @elleryames 