### PR TITLE
feat(eager): Eager & Execute for easier debugging

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,13 +13,14 @@ Workflows are a collection of tasks or steps designed to automate complex proces
 ### What Makes Dewret Unique? Why should I use Dewret?
 
 Dewret stands out by providing a unified and simplified interface for workflow management, making it accessible to users with varying levels of experience. Here are some key features that make Dewret unique:
-- Consistency: offers a consistent interface for defining tasks and workflows.
-- Optimization: creating a declarative workflow opens up possibilities for static analysis and refactoring before execution.
-- Customization: dewret offers the ability to create custom renderers for workflows in desired languages. This includes default support for CWL and Snakemake workflow languages. The capability to render a single workflow into multiple declarative languages enables users to experiment with different workflow engines.
-- Git-versionable workflows: while code can be versioned, changes in a dynamic workflow may not clearly correspond to changes in the executed workflow. By defining a static workflow that is rendered from the dynamic or programmatic workflow, we maintain a precise and trackable history.
-- Default Renderers: Snakemake and CWL.
-- Debugging: a number of classes of workflow planning bugs will not appear until late in a simulation run that might take days or weeks. Having a declarative and static workflow definition document post-render provides enhanced possibilities for static analysis, helping to catch these issues before startup.
-- Continuous Integration and Testing: complex dynamic workflows can be rapidly sense-checked in CI without needing all the hardware and internal algorithms present to run them.
+
+- **Consistency**: offers a consistent interface for defining tasks and workflows.
+- **Optimization**: creating a declarative workflow opens up possibilities for static analysis and refactoring before execution.
+- **Customization**: dewret offers the ability to create custom renderers for workflows in desired languages. This includes default support for CWL and Snakemake workflow languages. The capability to render a single workflow into multiple declarative languages enables users to experiment with different workflow engines.
+- **Git-versionable workflows**: while code can be versioned, changes in a dynamic workflow may not clearly correspond to changes in the executed workflow. By defining a static workflow that is rendered from the dynamic or programmatic workflow, we maintain a precise and trackable history.
+- **Default Renderers**: Snakemake and CWL.
+- **Debugging**: a number of classes of workflow planning bugs will not appear until late in a simulation run that might take days or weeks. Having a declarative and static workflow definition document post-render provides enhanced possibilities for static analysis, helping to catch these issues before startup.
+- **Continuous Integration and Testing**: complex dynamic workflows can be rapidly sense-checked in CI without needing all the hardware and internal algorithms present to run them.
 
 ## Installation for pure users
 

--- a/docs/renderer_tutorial.md
+++ b/docs/renderer_tutorial.md
@@ -8,6 +8,7 @@ Before writing any code, it is essential to fully understand the target workflow
 ### Example: 
 
 In Snakemake, a workflow task is generally created by:
+
 1. Defining the task. - `rule process_data`
 2. Defining the input required for the rule to run(dependencies). - `input: "data/raw_data.txt"`
 3. Defining the output required for the rule to be considered finished. - `output: "data/processed_data.txt"`

--- a/src/dewret/__main__.py
+++ b/src/dewret/__main__.py
@@ -51,6 +51,13 @@ from .tasks import Backend, construct
     help="Pretty-print output where possible.",
 )
 @click.option(
+    "--eager",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Eagerly evaluate tasks at render-time for debugging purposes.",
+)
+@click.option(
     "--backend",
     type=click.Choice(list(Backend.__members__)),
     show_default=True,
@@ -81,6 +88,7 @@ def render(
     task: str,
     arguments: list[str],
     pretty: bool,
+    eager: bool,
     backend: Backend,
     construct_args: str,
     renderer: str,
@@ -153,6 +161,13 @@ def render(
     pkg = "__workflow__"
     workflow = load_module_or_package(pkg, workflow_py)
     task_fn = getattr(workflow, task)
+
+    if eager:
+        construct_kwargs["eager"] = True
+        with set_configuration(**construct_kwargs):
+            output = task_fn(**kwargs)
+        print(output)
+        return
 
     try:
         with (

--- a/src/dewret/backends/_base.py
+++ b/src/dewret/backends/_base.py
@@ -33,7 +33,7 @@ class BackendModule(Protocol):
     """
     lazy: LazyFactory
 
-    def run(self, workflow: Workflow | None, task: Lazy | list[Lazy] | tuple[Lazy], thread_pool: ThreadPoolExecutor | None=None) -> StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any]]:
+    def run(self, workflow: Workflow | None, task: Lazy | list[Lazy] | tuple[Lazy, ...], thread_pool: ThreadPoolExecutor | None=None) -> StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any]]:
         """Execute a lazy task for this `Workflow`.
 
         Args:

--- a/src/dewret/backends/backend_dask.py
+++ b/src/dewret/backends/backend_dask.py
@@ -98,7 +98,7 @@ lazy = delayed
 
 def run(
     workflow: Workflow | None,
-    task: Lazy | list[Lazy] | tuple[Lazy],
+    task: Lazy | list[Lazy] | tuple[Lazy, ...],
     thread_pool: ThreadPoolExecutor | None = None,
     **kwargs: Any,
 ) -> Any:

--- a/src/dewret/core.py
+++ b/src/dewret/core.py
@@ -186,6 +186,7 @@ class ConstructConfiguration:
     field_separator: str = "/"
     field_index_types: str = "int"
     simplify_ids: bool = False
+    eager: bool = False
 
 
 class ConstructConfigurationTypedDict(TypedDict):
@@ -203,6 +204,7 @@ class ConstructConfigurationTypedDict(TypedDict):
     field_separator: NotRequired[str]
     field_index_types: NotRequired[str]
     simplify_ids: NotRequired[bool]
+    eager: NotRequired[bool]
 
 
 @define

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -1151,12 +1151,22 @@ class BaseStep(WorkflowComponent):
 
         return f"{self.task}-{hasher(comp_tup)}"
 
+    def __call__(self, **additional_kwargs: Any) -> Any:
+        """Evaluate this step eagerly.
+
+        Args:
+            **additional_kwargs: any extra/overriding arguments to the step.
+        """
+        raise NotImplementedError("No eager evaluation for this BaseStep type")
+
 
 class NestedStep(BaseStep):
     """Calling out to a subworkflow.
 
     Type of BaseStep to call a subworkflow, which holds a reference to it.
     """
+
+    task: Workflow
 
     def __init__(
         self,
@@ -1205,11 +1215,31 @@ class NestedStep(BaseStep):
             raise RuntimeError("Can only use a subworkflow if the reference exists.")
         return self.__subworkflow__.result_type
 
+    def __call__(self, **additional_kwargs: Any) -> Any:
+        """Evaluate this nested step, by eagerly evaluating the subworkflow result.
+
+        Args:
+            **additional_kwargs: any extra/overriding arguments to the subworkflow result step.
+        """
+        kwargs: dict[str, Any] = dict(self.arguments)
+        kwargs.update(additional_kwargs)
+        return execute_step(self.__subworkflow__.result, **kwargs)
+
 
 class Step(BaseStep):
     """Regular step."""
 
-    ...
+    task: Task
+
+    def __call__(self, **additional_kwargs: Any) -> Any:
+        """Evaluate this step, by eagerly evaluating the result.
+
+        Args:
+            **additional_kwargs: any extra/overriding arguments to the step.
+        """
+        kwargs: dict[str, Any] = dict(self.arguments)
+        kwargs.update(additional_kwargs)
+        return self.task.target(**kwargs)
 
 
 class FactoryCall(Step):
@@ -1605,6 +1635,27 @@ class StepReference(FieldableMixin, Reference[U]):
         if "workflow" not in kwargs:
             kwargs["workflow"] = self.__workflow__
         return self._.step.make_reference(**kwargs)
+
+def execute_step(task: Any, **kwargs: Any) -> Any:
+    """Evaluate a single task for a known workflow.
+
+    Args:
+        task: the task to evaluate.
+        **kwargs: any arguments to pass to the task.
+    """
+    if isinstance(task, list):
+        return [execute_step(t, **kwargs) for t in task]
+    elif isinstance(task, tuple):
+        return tuple(execute_step(t, **kwargs) for t in task)
+
+    if not isinstance(task, StepReference):
+        raise TypeError(
+            f"Attempted to execute a task that is not step-like (Step/Workflow): {type(task)}"
+        )
+
+    result = task._.step()
+
+    return result
 
 class IterableStepReference(IterableMixin[U], StepReference[U]):
     """Iterable form of a step reference."""

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -1,3 +1,4 @@
+from attrs import define
 from dewret.tasks import task, workflow
 
 from .other import nothing
@@ -5,6 +6,15 @@ from .other import nothing
 JUMP: float = 1.0
 test: float = nothing
 
+
+@define
+class PackResult:
+    """A class representing the counts of card suits in a deck, including hearts, clubs, spades, and diamonds."""
+
+    hearts: int
+    clubs: int
+    spades: int
+    diamonds: int
 
 @workflow()
 def try_nothing() -> int:
@@ -69,3 +79,5 @@ def reverse_list(to_sort: list[int | float]) -> list[int | float]:
 @task()
 def max_list(lst: list[int | float]) -> int | float:
     return max(lst)
+
+

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,5 +1,7 @@
+"""Check eager behaviour and execution to evaluate a task/workflow."""
+
 import math
-from sympy import Expr, Symbol as S
+from sympy import Expr
 
 from dewret.tasks import (
     workflow,

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,78 @@
+import math
+from sympy import Expr, Symbol as S
+
+from dewret.tasks import (
+    workflow,
+    factory,
+    task,
+    evaluate,
+)
+from dewret.core import set_configuration
+from ._lib.extra import (
+    pi,
+    PackResult
+)
+
+def test_basic_eager_execution() -> None:
+    """Check whether we can run a simple flow without lazy-evaluation.
+
+    Will skip dask delayeds and execute during construction.
+    """
+    result = pi()
+
+    # Execute this step immediately.
+    output = evaluate(result, execute=True)
+    assert output == math.pi
+
+    with set_configuration(eager=True):
+        output = pi()
+
+    assert output == math.pi
+
+def test_eager_execution_of_a_workflow() -> None:
+    """Check whether we can run a workflow without lazy-evaluation.
+
+    Will skip dask delayeds and execute during construction.
+    """
+    @workflow()
+    def pair_pi() -> tuple[float, float]:
+        return pi(), pi()
+
+    # Execute this step immediately.
+    with set_configuration(flatten_all_nested=True):
+        result = pair_pi()
+        output = evaluate(result, execute=True)
+
+    assert output == (math.pi, math.pi)
+
+    with set_configuration(eager=True):
+        output = pair_pi()
+
+    assert output == (math.pi, math.pi)
+
+
+def test_eager_execution_of_a_rich_workflow() -> None:
+    """Ensures that a workflow with both tasks and workflows can be eager-evaluated."""
+    Pack = factory(PackResult)
+
+    @task()
+    def sum(left: int, right: int) -> int:
+        return left + right
+
+    @workflow()
+    def black_total(pack: PackResult) -> int:
+        return sum(left=pack.spades, right=pack.clubs)
+
+    pack = Pack(hearts=13, spades=13, diamonds=13, clubs=13)
+
+    output_sympy: Expr = evaluate(black_total(pack=pack), execute=True)
+    clubs, spades = output_sympy.free_symbols
+    output: int = output_sympy.subs({spades: 13, clubs: 13})
+
+    assert output == 26
+
+    with set_configuration(eager=True):
+        pack = Pack(hearts=13, spades=13, diamonds=13, clubs=13)
+        output = black_total(pack=pack)
+
+    assert output == 26

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -7,9 +7,8 @@ from dewret.tasks import construct, workflow, task, factory
 from dewret.core import set_configuration
 from dewret.renderers.cwl import render
 from dewret.workflow import param
-from attrs import define
 
-from ._lib.extra import increment, sum, pi
+from ._lib.extra import increment, sum, pi, PackResult
 
 CONSTANT: int = 3
 
@@ -557,16 +556,6 @@ def test_subworkflows_can_use_globals_in_right_scope() -> None:
             run: to_int
     """),
     )
-
-
-@define
-class PackResult:
-    """A class representing the counts of card suits in a deck, including hearts, clubs, spades, and diamonds."""
-
-    hearts: int
-    clubs: int
-    spades: int
-    diamonds: int
 
 
 def test_combining_attrs_and_factories() -> None:


### PR DESCRIPTION
## ✨ Feature: Eager & Execute for easier debugging

### Description

Provides ability to eagerly evaluate _or_ execute a lazy evaluation.

**Eager**: that is, never to use laziness at all and the task/workflow decorator calls the wrapped function immediately.
**Execute**: once a lazy evaluation exists (e.g. workflow result) calling execute gets a value from it, _without_ using the backend (i.e. by calling all the functions).

The difference between `execute` and normal dask evaluation is that dewret does not use an executor, and simply calls the functions recursively, which may simplify debugging.

### Changes Made

- Command-line and construct-time flag for `--eager` to get an immediate result printed to `stdout`.
- Addition of `execute` to workflow, that will call any tasks to get a final result _after_ the workflow/task is constructed.
- `test_executions.py`: script to confirm the new functionality

### Additional Information

Requested given the nonlinear nature of debugging. This has been confirmed to allow step-wise debugging in PyCharm, by adding `--eager` into the command line.

Tip: adding `DEFAULT_WORKFLOW = workflow_to_test` to the bottom of a workflow file, and making the command-line for debugging to be `-m dewret $FilePath$ DEFAULT_WORKFLOW --eager` will save having to change the configuration to swap between debugged workflows.

### Checklist

- [x] I have included a detailed description of the feature.
- [ ] I have provided relevant documentation for my feature.
- [x] I have added the necessary tests.

### Who can review?

@KamenDimitrov97 @elleryames (written by @philtweir and @edufnt )
