### PR TITLE
fix(docs): replace github link for portray with a temporary pypi url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ allow-direct-references = true
 [project.optional-dependencies]
 test = ["pytest", "coverage", "ruff", "mypy"]
 docs = [
-  "portray @ git+https://github.com/flaxandteal/portray.git#v1.8.0-fat"
+  "tmp_fat_portray >= v1.8.0"
 ]
 
 [tool.pixi.project]


### PR DESCRIPTION
## 🐛 Bug Fix

### Description

Currently, we cannot release (at least to PyPI) as the fork of Portray, and of pdocs, is not packaged. Temporary packages have been created ahead of investigating upstream interest in updates.

To reproduce, pushing a tag to main with a new version leads to a failing build on upload to PyPI.

### Root Cause:

As portray and pdocs are abandoned, more recent versions of numpy are incompatible with hug. As a result, we have had to remove hug, which is not critical for our use-case. Functionality in portray (a) is more generally attractive as it integrates mkdocs alos, and (b) project-level issues with pdoc and pdoc3 mean these will not be accepted as dependencies, and pdocs is the only universally-acceptable feature-equivalent alternative.

### Testing:

Tried installing this locally, with no issues.

### Checklist

- [x] I have included a clear description of the bug.
- [x] I have listed the steps to reproduce the issue.
- [x] I have run the test suite and verified it passes.
- [x] I have attached any relevant logs or screenshots. (N/A)

### Who can review?

List any maintainers or contributors who are best suited to review this pull request.

@KamenDimitrov97 @elleryames 