### PR TITLE
Release: 0.10.0

### DIFF
--- a/.github/workflows/python-static-ci.yml
+++ b/.github/workflows/python-static-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: python/mypy@v1.8.0
         with:
           paths: "./src"
-      - run: pip install .[test] && python -m mypy --strict --install-types --non-interactive ./src ./tests ./example
+      - run: pip install .[test] && python -m mypy --strict --install-types --allow-subclassing-any --non-interactive ./src ./tests ./example
 
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-test-ci.yml
+++ b/.github/workflows/python-test-ci.yml
@@ -48,6 +48,6 @@ jobs:
         $CONDA/bin/pytest
         python -m pytest --doctest-modules --ignore=example --ignore=tests/_lib
         python -m doctest -v docs/*.md
-    name: Test examples
-    run: |
-      (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
+    - name: Test examples
+      run: |
+        (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")

--- a/.github/workflows/python-test-ci.yml
+++ b/.github/workflows/python-test-ci.yml
@@ -3,12 +3,16 @@ on: [push, pull_request]
 jobs:
   unit-pip:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
+
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip "hatchling < 1.22"
@@ -17,11 +21,11 @@ jobs:
       run: |
         pip install pytest pytest-cov
         pip install --no-build-isolation --no-deps --disable-pip-version-check -e .
-        python -m pytest --doctest-modules --ignore=example
+        python -m pytest --doctest-modules --ignore=example --ignore=tests/_lib
         python -m doctest -v docs/*.md
-    # name: Test examples
-    # run: |
-    #   (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
+    name: Test examples
+    run: |
+      (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
   unit-conda:
     runs-on: ubuntu-latest
     steps:
@@ -42,8 +46,8 @@ jobs:
         conda install -c /tmp/output/noarch/*.conda --update-deps --use-local dewret -y
         conda install pytest
         $CONDA/bin/pytest
-        python -m pytest --doctest-modules --ignore=example
+        python -m pytest --doctest-modules --ignore=example --ignore=tests/_lib
         python -m doctest -v docs/*.md
-    # name: Test examples
-    # run: |
-    #   (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
+    name: Test examples
+    run: |
+      (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")

--- a/.github/workflows/python-test-ci.yml
+++ b/.github/workflows/python-test-ci.yml
@@ -2,7 +2,7 @@ name: Test
 on: [push, pull_request]
 jobs:
   unit-pip:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/python-test-ci.yml
+++ b/.github/workflows/python-test-ci.yml
@@ -2,7 +2,7 @@ name: Test
 on: [push, pull_request]
 jobs:
   unit-pip:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/python-test-ci.yml
+++ b/.github/workflows/python-test-ci.yml
@@ -23,9 +23,9 @@ jobs:
         pip install --no-build-isolation --no-deps --disable-pip-version-check -e .
         python -m pytest --doctest-modules --ignore=example --ignore=tests/_lib
         python -m doctest -v docs/*.md
-    name: Test examples
-    run: |
-      (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
+    - name: Test examples
+      run: |
+        (cd example; examples=$(grep "^\\$ " *.py | sed "s/.*\\$ //g"); while IFS= read -r line; do PYTHONPATH=.:$PYTHONPATH eval $line; done <<< "$examples")
   unit-conda:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ ENV/
 env.bak/
 venv.bak/
 .pixi/
+.vscode/
 
 # Spyder project settings
 .spyderproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,17 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --fix ]
+        args: [--fix]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.8.0
     hooks:
       - id: mypy
-        args: [--strict, --install-types, --non-interactive]
+        args: [
+          --strict,
+          --install-types,
+          --allow-subclassing-any,
+          --non-interactive,
+        ]
         additional_dependencies: [sympy, attrs, pytest, click, dask]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.14.0
     hooks:
       - id: mypy
         args: [

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,14 +97,14 @@ and backends, as well as bespoke serialization or formatting.
 >>>
 >>> result = increment(num=3)
 >>> workflow = construct(result, simplify_ids=True)
->>> cwl = render(workflow)
+>>> cwl = render(workflow)["__root__"]
 >>> yaml.dump(cwl, sys.stdout, indent=2)
 class: Workflow
 cwlVersion: 1.2
 inputs:
   increment-1-num:
     default: 3
-    label: increment-1-num
+    label: num
     type: int
 outputs:
   out:

--- a/example/snakemake_renderer/basic_example/snakemake_workflow.py
+++ b/example/snakemake_renderer/basic_example/snakemake_workflow.py
@@ -172,5 +172,5 @@ if __name__ == "__main__":
                 "]": "",
             }
         )
-        smk_output = yaml.dump(smk_output, indent=4).translate(trans_table)
-        file.write(smk_output)
+        smk_text = yaml.dump(smk_output, indent=4).translate(trans_table)
+        file.write(smk_text)

--- a/example/workflow_complex.py
+++ b/example/workflow_complex.py
@@ -7,13 +7,13 @@ $ python -m dewret workflow_complex.py --pretty nested_workflow
 ```
 """
 
-from dewret.tasks import subworkflow
+from dewret.tasks import workflow
 from workflow_tasks import sum, double, increase
 
 STARTING_NUMBER: int = 23
 
 
-@subworkflow()
+@workflow()
 def nested_workflow() -> int | float:
     """Creates a complex workflow with a nested task.
 

--- a/example/workflow_qs.py
+++ b/example/workflow_qs.py
@@ -9,6 +9,7 @@ $ python -m dewret workflow_qs.py --pretty increment num:3 --backend DASK
 
 from dewret.tasks import task
 
+
 @task()
 def increment(num: int) -> int:
     """Add 1 to a number."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+strict = True
+# Required to allow subclassing of sympy.Symbol
+disallow_subclassing_any = False
+
+[mypy-sympy.*]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ homepage = "https://github.com/flaxandteal/dewret"
 repository = "https://github.com/flaxandteal/dewret"
 documentation = "https://flaxandteal.github.io/dewret"
 readme = "README.md"
-version = "0.9.1"
+version = "0.10.0"
 authors = [
   {name = "Phil Weir", email = "phil.weir@flaxandteal.co.uk"},
   {name = "Chris Nixon", email = "chris.nixon@sigma-sc.co.uk"},

--- a/src/dewret/__main__.py
+++ b/src/dewret/__main__.py
@@ -20,13 +20,25 @@ this may be of use.
 """
 
 import importlib
+import importlib.util
 from pathlib import Path
-import yaml
+from contextlib import contextmanager
 import sys
+import re
+import yaml
+from typing import Any, IO, Generator
+from types import ModuleType
 import click
 import json
 
-from .renderers.cwl import render as cwl_render
+from .core import (
+    set_configuration,
+    set_render_configuration,
+    RawRenderModule,
+    StructuredRenderModule,
+)
+from .utils import load_module_or_package
+from .render import get_render_method, write_rendered_output
 from .tasks import Backend, construct
 
 
@@ -45,11 +57,35 @@ from .tasks import Backend, construct
     default=Backend.DASK.name,
     help="Backend to use for workflow evaluation.",
 )
-@click.argument("workflow_py")
+@click.option(
+    "--construct-args",
+    default="simplify_ids:true"
+)
+@click.option(
+    "--renderer",
+    default="cwl"
+)
+@click.option(
+    "--renderer-args",
+    default=""
+)
+@click.option(
+    "--output",
+    default="-"
+)
+@click.argument("workflow_py", type=click.Path(exists=True, path_type=Path))
 @click.argument("task")
 @click.argument("arguments", nargs=-1)
 def render(
-    workflow_py: str, task: str, arguments: list[str], pretty: bool, backend: Backend
+    workflow_py: Path,
+    task: str,
+    arguments: list[str],
+    pretty: bool,
+    backend: Backend,
+    construct_args: str,
+    renderer: str,
+    renderer_args: str,
+    output: str,
 ) -> None:
     """Render a workflow.
 
@@ -57,10 +93,7 @@ def render(
     TASK is the name of (decorated) task in workflow module.
     ARGUMENTS is zero or more pairs representing constant arguments to pass to the task, in the format `key:val` where val is a JSON basic type.
     """
-    sys.path.append(str(Path(workflow_py).parent))
-    loader = importlib.machinery.SourceFileLoader("workflow", workflow_py)
-    workflow = loader.load_module()
-    task_fn = getattr(workflow, task)
+    sys.path.append(str(workflow_py.parent))
     kwargs = {}
     for arg in arguments:
         if ":" not in arg:
@@ -70,18 +103,72 @@ def render(
         key, val = arg.split(":", 1)
         kwargs[key] = json.loads(val)
 
+    render_module: Path | ModuleType
+    if mtch := re.match(r"^([a-z_0-9-.]+)$", renderer):
+        render_module = importlib.import_module(f"dewret.renderers.{mtch.group(1)}")
+        if not isinstance(render_module, RawRenderModule) and not isinstance(render_module, StructuredRenderModule):
+            raise NotImplementedError("The imported render module does not seem to match the `RawRenderModule` or `StructuredRenderModule` protocols.")
+    elif renderer.startswith("@"):
+        render_module = Path(renderer[1:])
+    else:
+        raise RuntimeError("Renderer argument should be a known dewret renderer, or '@FILENAME' where FILENAME is a renderer")
+
+    if construct_args.startswith("@"):
+        with Path(construct_args[1:]).open() as construct_args_f:
+            construct_kwargs = yaml.safe_load(construct_args_f)
+    elif not construct_args:
+        construct_kwargs = {}
+    else:
+        construct_kwargs = dict(pair.split(":") for pair in construct_args.split(","))
+
+    renderer_kwargs: dict[str, Any]
+    if renderer_args.startswith("@"):
+        with Path(renderer_args[1:]).open() as renderer_args_f:
+            renderer_kwargs = yaml.safe_load(renderer_args_f)
+    elif not renderer_args:
+        renderer_kwargs = {}
+    else:
+        renderer_kwargs = dict(pair.split(":") for pair in renderer_args.split(","))
+
+    if output == "-":
+
+        @contextmanager
+        def _opener(key: str, _: str) -> Generator[IO[Any], None, None]:
+            print(" ------ ", key, " ------ ")
+            yield sys.stdout
+            print()
+
+        opener = _opener
+    else:
+
+        @contextmanager
+        def _opener(key: str, mode: str) -> Generator[IO[Any], None, None]:
+            output_file = output.replace("%", key)
+            with Path(output_file).open(mode) as output_f:
+                yield output_f
+
+        opener = _opener
+
+    render = get_render_method(render_module, pretty=pretty)
+    pkg = "__workflow__"
+    workflow = load_module_or_package(pkg, workflow_py)
+    task_fn = getattr(workflow, task)
+
     try:
-        cwl = cwl_render(construct(task_fn(**kwargs), simplify_ids=True))
+        with (
+            set_configuration(**construct_kwargs),
+            set_render_configuration(renderer_kwargs),
+        ):
+            rendered = render(
+                construct(task_fn(**kwargs), **construct_kwargs), **renderer_kwargs
+            )
     except Exception as exc:
         import traceback
 
         print(exc, exc.__cause__, exc.__context__)
         traceback.print_exc()
     else:
-        if pretty:
-            yaml.dump(cwl, sys.stdout, indent=2)
-        else:
-            print(cwl)
+        write_rendered_output(rendered, output, opener)
 
 
 render()

--- a/src/dewret/__main__.py
+++ b/src/dewret/__main__.py
@@ -57,22 +57,10 @@ from .tasks import Backend, construct
     default=Backend.DASK.name,
     help="Backend to use for workflow evaluation.",
 )
-@click.option(
-    "--construct-args",
-    default="simplify_ids:true"
-)
-@click.option(
-    "--renderer",
-    default="cwl"
-)
-@click.option(
-    "--renderer-args",
-    default=""
-)
-@click.option(
-    "--output",
-    default="-"
-)
+@click.option("--construct-args", default="simplify_ids:true")
+@click.option("--renderer", default="cwl")
+@click.option("--renderer-args", default="")
+@click.option("--output", default="-")
 @click.argument("workflow_py", type=click.Path(exists=True, path_type=Path))
 @click.argument("task")
 @click.argument("arguments", nargs=-1)
@@ -106,12 +94,18 @@ def render(
     render_module: Path | ModuleType
     if mtch := re.match(r"^([a-z_0-9-.]+)$", renderer):
         render_module = importlib.import_module(f"dewret.renderers.{mtch.group(1)}")
-        if not isinstance(render_module, RawRenderModule) and not isinstance(render_module, StructuredRenderModule):
-            raise NotImplementedError("The imported render module does not seem to match the `RawRenderModule` or `StructuredRenderModule` protocols.")
+        if not isinstance(render_module, RawRenderModule) and not isinstance(
+            render_module, StructuredRenderModule
+        ):
+            raise NotImplementedError(
+                "The imported render module does not seem to match the `RawRenderModule` or `StructuredRenderModule` protocols."
+            )
     elif renderer.startswith("@"):
         render_module = Path(renderer[1:])
     else:
-        raise RuntimeError("Renderer argument should be a known dewret renderer, or '@FILENAME' where FILENAME is a renderer")
+        raise RuntimeError(
+            "Renderer argument should be a known dewret renderer, or '@FILENAME' where FILENAME is a renderer"
+        )
 
     if construct_args.startswith("@"):
         with Path(construct_args[1:]).open() as construct_args_f:

--- a/src/dewret/__main__.py
+++ b/src/dewret/__main__.py
@@ -133,7 +133,7 @@ def render(
     if output == "-":
 
         @contextmanager
-        def _opener(key: str, _: str) -> Generator[IO[Any], None, None]:
+        def _opener(key: str, mode: str) -> Generator[IO[Any], None, None]:
             print(" ------ ", key, " ------ ")
             yield sys.stdout
             print()

--- a/src/dewret/_cpython_mod.py
+++ b/src/dewret/_cpython_mod.py
@@ -11,6 +11,7 @@ from inspect import (
 )
 from typing import Callable, Any
 
+
 def getclosurevars(func: Callable[..., Any]) -> ClosureVars:
     if ismethod(func):
         func = func.__func__
@@ -25,9 +26,9 @@ def getclosurevars(func: Callable[..., Any]) -> ClosureVars:
         nonlocal_vars = {}
     else:
         nonlocal_vars = {
-            var : cell.cell_contents
-            for var, cell in zip(code.co_freevars, func.__closure__)
-       }
+            var: cell.cell_contents
+            for var, cell in zip(code.co_freevars, func.__closure__, strict=False)
+        }
 
     # Global and builtin references are named in co_names and resolved
     # by looking them up in __globals__ or __builtins__
@@ -59,5 +60,4 @@ def getclosurevars(func: Callable[..., Any]) -> ClosureVars:
             except KeyError:
                 unbound_names.add(name)
 
-    return ClosureVars(nonlocal_vars, global_vars,
-                       builtin_vars, unbound_names)
+    return ClosureVars(nonlocal_vars, global_vars, builtin_vars, unbound_names)

--- a/src/dewret/_cpython_mod.py
+++ b/src/dewret/_cpython_mod.py
@@ -1,0 +1,63 @@
+# Insert Python copyright
+# This file: PSL 2.0
+
+import builtins
+import dis
+from inspect import (
+    ClosureVars,
+    ismethod,
+    isfunction,
+    ismodule,
+)
+from typing import Callable, Any
+
+def getclosurevars(func: Callable[..., Any]) -> ClosureVars:
+    if ismethod(func):
+        func = func.__func__
+
+    if not isfunction(func):
+        raise TypeError("{!r} is not a Python function".format(func))
+
+    code = func.__code__
+    # Nonlocal references are named in co_freevars and resolved
+    # by looking them up in __closure__ by positional index
+    if func.__closure__ is None:
+        nonlocal_vars = {}
+    else:
+        nonlocal_vars = {
+            var : cell.cell_contents
+            for var, cell in zip(code.co_freevars, func.__closure__)
+       }
+
+    # Global and builtin references are named in co_names and resolved
+    # by looking them up in __globals__ or __builtins__
+    global_ns = func.__globals__
+    builtin_ns = global_ns.get("__builtins__", builtins.__dict__)
+    if ismodule(builtin_ns):
+        builtin_ns = builtin_ns.__dict__
+    global_vars = {}
+    builtin_vars = {}
+    unbound_names = set()
+    global_names = set()
+    stackm1 = None
+    for instruction in dis.get_instructions(code):
+        opname = instruction.opname
+        name = instruction.argval
+        if opname == "LOAD_ATTR":
+            unbound_names.add(f"{stackm1}.{name}")
+            stackm1 = None
+        elif opname == "LOAD_FAST":
+            stackm1 = name
+        elif opname == "LOAD_GLOBAL":
+            global_names.add(name)
+    for name in global_names:
+        try:
+            global_vars[name] = global_ns[name]
+        except KeyError:
+            try:
+                builtin_vars[name] = builtin_ns[name]
+            except KeyError:
+                unbound_names.add(name)
+
+    return ClosureVars(nonlocal_vars, global_vars,
+                       builtin_vars, unbound_names)

--- a/src/dewret/annotations.py
+++ b/src/dewret/annotations.py
@@ -210,6 +210,19 @@ class FunctionAnalyser:
             fn_globals = {}
         return fn_globals
 
+    @property
+    def unbound(self) -> dict[str, str | None]:
+        """Get the globals for this Callable."""
+        fn_tuple = getclosurevars(self.fn)
+        unbound: dict[str, str | None] = {}
+        for var in fn_tuple.unbound:
+            if ":" in var:
+                ref, impt = var.split(":")
+                unbound[ref] = impt
+            else:
+                unbound[ref] = None
+        return unbound
+
     def with_new_globals(self, new_globals: dict[str, Any]) -> Callable[..., Any]:
         """Create a Callable that will run the current Callable with new globals."""
         code = self.fn.__code__

--- a/src/dewret/annotations.py
+++ b/src/dewret/annotations.py
@@ -1,0 +1,224 @@
+# Copyright 2024- Flax & Teal Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tooling for managing annotations.
+
+Provides `FunctionAnalyser`, a toolkit that takes a `Callable` and can interrogate it
+for annotations, with some intelligent searching beyond the obvious location.
+"""
+
+import inspect
+import ast
+import sys
+import importlib
+from functools import lru_cache
+from types import FunctionType, ModuleType
+from typing import (
+    Any,
+    TypeVar,
+    Annotated,
+    Callable,
+    get_origin,
+    get_args,
+    Mapping,
+    get_type_hints,
+)
+
+T = TypeVar("T")
+AtRender = Annotated[T, "AtRender"]
+Fixed = Annotated[T, "Fixed"]
+
+
+class FunctionAnalyser:
+    """Convenience class for analysing a function with reduced duplication of effort.
+
+    Attributes:
+        _fn: the wrapped callable
+        _annotations: stored annotations for the function.
+    """
+
+    _fn: Callable[..., Any]
+    _annotations: dict[str, Any]
+
+    def __init__(self, fn: Callable[..., Any]):
+        """Set the function.
+
+        If `fn` is a class, it takes the constructor, and if it is a method, it takes
+        the `__func__` attribute.
+        """
+        if inspect.isclass(fn):
+            self.fn = fn.__init__
+        elif inspect.ismethod(fn):
+            self.fn = fn.__func__
+        else:
+            self.fn = fn
+
+    @property
+    def return_type(self) -> Any:
+        """Return type of the callable.
+
+        Returns: expected type of the return value.
+
+        Raises:
+          ValueError: if the return value does not appear to be type-hinted.
+        """
+        hints = get_type_hints(inspect.unwrap(self.fn), include_extras=True)
+        if "return" not in hints or hints["return"] is None:
+            raise ValueError(f"Could not find type-hint for return value of {self.fn}")
+        typ = hints["return"]
+        return typ
+
+    @staticmethod
+    def _typ_has(typ: type, annotation: type) -> bool:
+        """Check if the type has an annotation.
+
+        Args:
+            typ: type to check.
+            annotation: the Annotated to compare against.
+
+        Returns: True if the type has the given annotation, otherwise False.
+        """
+        if not hasattr(annotation, "__metadata__"):
+            return False
+        if origin := get_origin(typ):
+            if (
+                origin is Annotated
+                and hasattr(typ, "__metadata__")
+                and typ.__metadata__ == annotation.__metadata__
+            ):
+                return True
+        if any(FunctionAnalyser._typ_has(arg, annotation) for arg in get_args(typ)):
+            return True
+        return False
+
+    def get_all_module_names(self) -> dict[str, Any]:
+        """Find all of the annotations within this module."""
+        return get_type_hints(sys.modules[self.fn.__module__], include_extras=True)
+
+    def get_all_imported_names(self) -> dict[str, tuple[ModuleType, str]]:
+        """Find all of the annotations that were imported into this module."""
+        return self._get_all_imported_names(sys.modules[self.fn.__module__])
+
+    @staticmethod
+    @lru_cache
+    def _get_all_imported_names(mod: ModuleType) -> dict[str, tuple[ModuleType, str]]:
+        """Get all of the names with this module, and their original locations.
+
+        Args:
+            mod: a module in the `sys.modules`.
+
+        Returns:
+            A dict whose keys are the known names in the current module, where the Callable lives,
+            and whose values are pairs of the module and the remote name.
+        """
+        ast_tree = ast.parse(inspect.getsource(mod))
+        imported_names = {}
+        for node in ast.walk(ast_tree):
+            if isinstance(node, ast.ImportFrom):
+                for name in node.names:
+                    imported_names[name.asname or name.name] = (
+                        importlib.import_module(
+                            "".join(["."] * node.level) + (node.module or ""),
+                            package=mod.__package__,
+                        ),
+                        name.name,
+                    )
+        return imported_names
+
+    @property
+    def free_vars(self) -> dict[str, Any]:
+        """Get the free variables for this Callable."""
+        if self.fn.__code__ and self.fn.__closure__:
+            return dict(
+                zip(
+                    self.fn.__code__.co_freevars,
+                    (c.cell_contents for c in self.fn.__closure__),
+                    strict=False,
+                )
+            )
+        return {}
+
+    def get_argument_annotation(self, arg: str, exhaustive: bool = False) -> Any:
+        """Retrieve the annotations for this argument.
+
+        Args:
+            arg: name of the argument.
+            exhaustive: True if we should search outside the function itself, into the module globals, and into imported modules.
+
+        Returns: annotation if available, else None.
+        """
+        typ: type | None = None
+        if typ := self.fn.__annotations__.get(arg):
+            if isinstance(typ, str):
+                typ = get_type_hints(self.fn, include_extras=True).get(arg)
+        elif exhaustive:
+            if anns := get_type_hints(
+                sys.modules[self.fn.__module__], include_extras=True
+            ):
+                if typ := anns.get(arg):
+                    ...
+                elif orig_pair := self.get_all_imported_names().get(arg):
+                    orig_module, orig_name = orig_pair
+                    typ = orig_module.__annotations__.get(orig_name)
+                elif value := self.free_vars.get(arg):
+                    if not inspect.isclass(value) or inspect.isfunction(value):
+                        raise RuntimeError(
+                            f"Cannot use free variables - please put {arg} at the global scope"
+                        )
+        return typ
+
+    def argument_has(
+        self, arg: str, annotation: type, exhaustive: bool = False
+    ) -> bool:
+        """Check if the named argument has the given annotation.
+
+        Args:
+            arg: argument to retrieve.
+            annotation: Annotated to search for.
+            exhaustive: whether to check the globals and other modules.
+
+        Returns: True if the Annotated is present in this argument's annotation.
+        """
+        typ = self.get_argument_annotation(arg, exhaustive)
+        return bool(typ and self._typ_has(typ, annotation))
+
+    def is_at_construct_arg(self, arg: str, exhaustive: bool = False) -> bool:
+        """Convience function to check for `AtConstruct`, wrapping `FunctionAnalyser.argument_has`."""
+        return self.argument_has(arg, AtRender, exhaustive)
+
+    @property
+    def globals(self) -> Mapping[str, Any]:
+        """Get the globals for this Callable."""
+        try:
+            fn_tuple = inspect.getclosurevars(self.fn)
+            fn_globals = dict(fn_tuple.globals)
+            fn_globals.update(fn_tuple.nonlocals)
+        # This covers the case of wrapping, rather than decorating.
+        except TypeError:
+            fn_globals = {}
+        return fn_globals
+
+    def with_new_globals(self, new_globals: dict[str, Any]) -> Callable[..., Any]:
+        """Create a Callable that will run the current Callable with new globals."""
+        code = self.fn.__code__
+        fn_name = self.fn.__name__
+        all_globals = dict(self.globals)
+        all_globals.update(new_globals)
+        return FunctionType(
+            code,
+            all_globals,
+            name=fn_name,
+            closure=self.fn.__closure__,
+            argdefs=self.fn.__defaults__,
+        )

--- a/src/dewret/annotations.py
+++ b/src/dewret/annotations.py
@@ -22,6 +22,7 @@ import inspect
 import ast
 import sys
 import importlib
+from ._cpython_mod import getclosurevars
 from functools import lru_cache
 from types import FunctionType, ModuleType
 from typing import (
@@ -201,7 +202,7 @@ class FunctionAnalyser:
     def globals(self) -> Mapping[str, Any]:
         """Get the globals for this Callable."""
         try:
-            fn_tuple = inspect.getclosurevars(self.fn)
+            fn_tuple = getclosurevars(self.fn)
             fn_globals = dict(fn_tuple.globals)
             fn_globals.update(fn_tuple.nonlocals)
         # This covers the case of wrapping, rather than decorating.

--- a/src/dewret/backends/_base.py
+++ b/src/dewret/backends/_base.py
@@ -18,6 +18,7 @@ Definition of a protocol that valid backend modules must fulfil.
 """
 
 from typing import Protocol, Any
+from concurrent.futures import ThreadPoolExecutor
 from dewret.workflow import LazyFactory, Lazy, Workflow, StepReference, Target
 
 class BackendModule(Protocol):
@@ -32,12 +33,13 @@ class BackendModule(Protocol):
     """
     lazy: LazyFactory
 
-    def run(self, workflow: Workflow, task: Lazy) -> StepReference[Any]:
+    def run(self, workflow: Workflow | None, task: Lazy | list[Lazy] | tuple[Lazy], thread_pool: ThreadPoolExecutor | None=None) -> StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any]]:
         """Execute a lazy task for this `Workflow`.
 
         Args:
             workflow: `Workflow` that is being executed.
             task: task that forms the output.
+            thread_pool: the thread pool that should be used for this execution.
 
         Returns:
             Reference to the final output step.

--- a/src/dewret/backends/_base.py
+++ b/src/dewret/backends/_base.py
@@ -21,6 +21,7 @@ from typing import Protocol, Any
 from concurrent.futures import ThreadPoolExecutor
 from dewret.workflow import LazyFactory, Lazy, Workflow, StepReference, Target
 
+
 class BackendModule(Protocol):
     """Requirements for a valid backend module.
 
@@ -31,9 +32,15 @@ class BackendModule(Protocol):
         lazy: Callable that takes a function and returns a lazy-evaluated
             version of it, appropriate to the backend.
     """
+
     lazy: LazyFactory
 
-    def run(self, workflow: Workflow | None, task: Lazy | list[Lazy] | tuple[Lazy], thread_pool: ThreadPoolExecutor | None=None) -> StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any]]:
+    def run(
+        self,
+        workflow: Workflow | None,
+        task: Lazy | list[Lazy] | tuple[Lazy],
+        thread_pool: ThreadPoolExecutor | None = None,
+    ) -> StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any]]:
         """Execute a lazy task for this `Workflow`.
 
         Args:

--- a/src/dewret/backends/backend_dask.py
+++ b/src/dewret/backends/backend_dask.py
@@ -36,7 +36,7 @@ class Delayed(Protocol):
     """
 
     @property
-    def __dask_graph__(self): # type: ignore
+    def __dask_graph__(self):  # type: ignore
         """Retrieve the dask graph."""
         ...
 

--- a/src/dewret/core.py
+++ b/src/dewret/core.py
@@ -1,0 +1,626 @@
+# Copyright 2024- Flax & Teal Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base classes that need to be available everywhere.
+
+Mainly tooling around configuration, protocols and superclasses for References
+and WorkflowComponents, that are concretized elsewhere.
+"""
+
+from dataclasses import dataclass
+import importlib
+import base64
+from attrs import define
+from functools import lru_cache
+from typing import (
+    Generic,
+    TypeVar,
+    Protocol,
+    Iterator,
+    Unpack,
+    TypedDict,
+    NotRequired,
+    Generator,
+    Any,
+    get_args,
+    get_origin,
+    Annotated,
+    Callable,
+    cast,
+    runtime_checkable,
+)
+from contextlib import contextmanager
+from contextvars import ContextVar
+from sympy import Expr, Symbol, Basic
+import copy
+
+BasicType = str | float | bool | bytes | int | None
+RawType = BasicType | list["RawType"] | dict[str, "RawType"]
+FirmType = RawType | list["FirmType"] | dict[str, "FirmType"] | tuple["FirmType", ...]
+ExprType = (FirmType | Basic | list["ExprType"] | dict[str, "ExprType"] | tuple["ExprType", ...]) # type: ignore
+
+U = TypeVar("U")
+T = TypeVar("T")
+
+
+def strip_annotations(parent_type: type) -> tuple[type, tuple[str]]:
+    """Discovers and removes annotations from a parent type.
+
+    Args:
+        parent_type: a type, possibly Annotated.
+
+    Returns: a parent type that is not Annotation, along with any stripped metadata, if present.
+
+    """
+    # Strip out any annotations. This should be auto-flattened, so in theory only one iteration could occur.
+    metadata = []
+    while get_origin(parent_type) is Annotated:
+        parent_type, *parent_metadata = get_args(parent_type)
+        metadata += list(parent_metadata)
+    return parent_type, tuple(metadata)
+
+
+# Generic type for configuration settings for the renderer
+RenderConfiguration = dict[str, RawType]
+
+
+class WorkflowProtocol(Protocol):
+    """Expected structure for a workflow.
+
+    We do not expect various workflow implementations, but this allows us to define the
+    interface expected by the core classes.
+    """
+
+    def remap(self, name: str) -> str:
+        """Perform any name-changing for steps, etc. in the workflow.
+
+        This enables, for example, simplifying all the IDs to an integer sequence.
+
+        Returns: remapped name.
+        """
+        ...
+
+    def set_result(self, result: Basic | list[Basic] | tuple[Basic]) -> None:
+        """Set the step that should produce a result for the overall workflow."""
+        ...
+
+    def simplify_ids(self, infix: list[str] | None = None) -> None:
+        """Drop the non-human-readable IDs if possible, in favour of integer sequences.
+
+        Args:
+            infix: any inherited intermediary identifiers, to allow nesting, or None.
+        """
+        ...
+
+
+class BaseRenderModule(Protocol):
+    """Common routines for all renderer modules."""
+
+    @staticmethod
+    def default_config() -> dict[str, RawType]:
+        """Retrieve default settings.
+
+        These will not change during execution, but can be overridden by `dewret.core.set_render_configuration`.
+
+        Returns: a static, serializable dict.
+        """
+        ...
+
+
+@runtime_checkable
+class RawRenderModule(BaseRenderModule, Protocol):
+    """Render module that returns raw text."""
+
+    def render_raw(
+        self, workflow: WorkflowProtocol, **kwargs: RenderConfiguration
+    ) -> dict[str, str]:
+        """Turn a workflow into flat strings.
+
+        Returns: one or more subworkflows with a `__root__` key representing the outermost workflow, at least.
+        """
+        ...
+
+
+@runtime_checkable
+class StructuredRenderModule(BaseRenderModule, Protocol):
+    """Render module that returns JSON/YAML-serializable structures."""
+
+    def render(
+        self, workflow: WorkflowProtocol, **kwargs: RenderConfiguration
+    ) -> dict[str, dict[str, RawType]]:
+        """Turn a workflow into a serializable structure.
+
+        Returns: one or more subworkflows with a `__root__` key representing the outermost workflow, at least.
+        """
+        ...
+
+
+class RenderCall(Protocol):
+    """Callable that will render out workflow(s)."""
+
+    def __call__(
+        self, workflow: WorkflowProtocol, **kwargs: RenderConfiguration
+    ) -> dict[str, str] | dict[str, RawType]:
+        """Take a workflow and turn it into a set of serializable (sub)workflows.
+
+        Args:
+            workflow: root workflow.
+            kwargs: configuration for the renderer.
+
+        Returns: a mapping of keys to serialized workflows, containing at least `__root__`.
+        """
+        ...
+
+
+class UnevaluatableError(Exception):
+    """Signposts that a user has tried to treat a reference as the real (runtime) value.
+
+    For example, by comparing to a concrete integer or value, etc.
+    """
+
+    ...
+
+
+@define
+class ConstructConfiguration:
+    """Basic configuration of the construction process.
+
+    Holds configuration that may be relevant to `construst(...)` calls or, realistically,
+    anything prior to rendering. It should hold generic configuration that is renderer-independent.
+    """
+
+    flatten_all_nested: bool = False
+    allow_positional_args: bool = False
+    allow_plain_dict_fields: bool = False
+    field_separator: str = "/"
+    field_index_types: str = "int"
+    simplify_ids: bool = False
+
+
+class ConstructConfigurationTypedDict(TypedDict):
+    """Basic configuration of the construction process.
+
+    Holds configuration that may be relevant to `construst(...)` calls or, realistically,
+    anything prior to rendering. It should hold generic configuration that is renderer-independent.
+
+    **THIS MUST BE KEPT IDENTICAL TO ConstructConfiguration.**
+    """
+
+    flatten_all_nested: NotRequired[bool]
+    allow_positional_args: NotRequired[bool]
+    allow_plain_dict_fields: NotRequired[bool]
+    field_separator: NotRequired[str]
+    field_index_types: NotRequired[str]
+    simplify_ids: NotRequired[bool]
+
+
+@define
+class GlobalConfiguration:
+    """Overall configuration structure.
+
+    Having a single configuration dict allows us to manage only one ContextVar.
+    """
+
+    construct: ConstructConfiguration
+    render: dict[str, RawType]
+
+
+CONFIGURATION: ContextVar[GlobalConfiguration] = ContextVar("configuration")
+
+
+@contextmanager
+def set_configuration(
+    **kwargs: Unpack[ConstructConfigurationTypedDict],
+) -> Iterator[ContextVar[GlobalConfiguration]]:
+    """Sets the construct-time configuration.
+
+    This is a context manager, so that a setting can be temporarily overridden and automatically restored.
+    """
+    with _set_configuration() as CONFIGURATION:
+        for key, value in kwargs.items():
+            setattr(CONFIGURATION.get().construct, key, value)
+        yield CONFIGURATION
+
+
+@contextmanager
+def set_render_configuration(
+    kwargs: dict[str, RawType],
+) -> Iterator[ContextVar[GlobalConfiguration]]:
+    """Sets the render-time configuration.
+
+    This is a context manager, so that a setting can be temporarily overridden and automatically restored.
+
+    Returns: the yielded global configuration ContextVar.
+    """
+    with _set_configuration() as CONFIGURATION:
+        CONFIGURATION.get().render.update(**kwargs)
+        yield CONFIGURATION
+
+
+@contextmanager
+def _set_configuration() -> Iterator[ContextVar[GlobalConfiguration]]:
+    """Prepares and tidied up the configuration for applying settings.
+
+    This is a context manager, so that a setting can be temporarily overridden and automatically restored.
+    """
+    try:
+        previous = CONFIGURATION.get()
+    except LookupError:
+        previous = GlobalConfiguration(
+            construct=ConstructConfiguration(), render=default_renderer_config()
+        )
+        CONFIGURATION.set(previous)
+    previous = copy.deepcopy(previous)
+
+    try:
+        yield CONFIGURATION
+    finally:
+        CONFIGURATION.set(previous)
+
+
+@lru_cache
+def default_renderer_config() -> RenderConfiguration:
+    """Gets the default renderer configuration.
+
+    This may be called frequently, but is cached so note that any changes to the
+    wrapped config function will _not_ be reflected during the process.
+
+    It is a light wrapper for `default_config` in the supplier renderer module.
+
+    Returns: the default configuration dict for the chosen renderer.
+    """
+    try:
+        # We have to use a cast as we do not know if the renderer module is valid.
+        render_module = cast(
+            BaseRenderModule, importlib.import_module("__renderer_mod__")
+        )
+        default_config: Callable[[], RenderConfiguration] = render_module.default_config
+    except ImportError:
+        return {}
+    return default_config()
+
+
+@lru_cache
+def default_construct_config() -> ConstructConfiguration:
+    """Gets the default construct-time configuration.
+
+    This is the primary mechanism for configuring dewret internals, so these defaults
+    should be carefully chosen and, if they change, that likely has an impact on backwards compatibility
+    from a SemVer perspective.
+
+    Returns: configuration dictionary with default construct values.
+    """
+    return ConstructConfiguration(
+        flatten_all_nested=False,
+        allow_positional_args=False,
+        allow_plain_dict_fields=False,
+        field_separator="/",
+        field_index_types="int",
+    )
+
+
+def get_configuration(key: str) -> RawType:
+    """Retrieve the configuration or (silently) return the default.
+
+    Helps avoid a proliferation of `set_configuration` calls by not erroring if it has not been called.
+    However, the cost is that the user may accidentally put configuration-affected logic outside a
+    set_configuration call and be surprised that the behaviour is inexplicibly not as expected.
+
+    Args:
+        key: configuration key to retrieve.
+
+    Returns: (preferably) a JSON/YAML-serializable construct.
+    """
+    try:
+        return getattr(CONFIGURATION.get().construct, key)  # type: ignore
+    except LookupError:
+        # TODO: Not sure what the best way to typehint this is.
+        return getattr(ConstructConfiguration(), key)  # type: ignore
+
+
+def get_render_configuration(key: str) -> RawType:
+    """Retrieve configuration for the active renderer.
+
+    Finds the current user-set configuration, defaulting back to the chosen renderer module's declared
+    defaults.
+
+    Args:
+        key: configuration key to retrieve.
+
+    Returns: (preferably) a JSON/YAML-serializable construct.
+    """
+    try:
+        return CONFIGURATION.get().render.get(key)
+    except LookupError:
+        return default_renderer_config().get(key)
+
+
+class WorkflowComponent:
+    """Base class for anything directly tied to an individual `Workflow`.
+
+    Attributes:
+        __workflow__: the `Workflow` that this is tied to.
+    """
+
+    __workflow_real__: WorkflowProtocol
+
+    def __init__(self, *args: Any, workflow: WorkflowProtocol, **kwargs: Any):
+        """Tie to a `Workflow`.
+
+        All subclasses must call this.
+
+        Args:
+            workflow: the `Workflow` to tie to.
+            *args: remainder of arguments for other initializers.
+            **kwargs: remainder of arguments for other initializers.
+        """
+        self.__workflow__ = workflow
+        super().__init__(*args, **kwargs)
+
+    @property
+    def __workflow__(self) -> WorkflowProtocol:
+        """Workflow to which this reference applies."""
+        return self.__workflow_real__
+
+    @__workflow__.setter
+    def __workflow__(self, workflow: WorkflowProtocol) -> None:
+        """Workflow to which this reference applies."""
+        self.__workflow_real__ = workflow
+
+
+class Reference(Generic[U], Symbol, WorkflowComponent):
+    """Superclass for all symbolic references to values."""
+
+    _type: type[U] | None = None
+    __iterated__: bool = False
+
+    def __init__(self, *args: Any, typ: type[U] | None = None, **kwargs: Any):
+        """Extract any specified type.
+
+        Args:
+            typ: type to override any inference, or None.
+            *args: any other arguments for other initializers (e.g. mixins).
+            **kwargs: any other arguments for other initializers (e.g. mixins).
+        """
+        self._type = typ
+        super().__init__(*args, **kwargs)
+
+    @property
+    def name(self) -> str:
+        """Printable name of the reference."""
+        return self.__name__
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Reference[U]":
+        """As all references are sympy Expressions, the real returned object must be made with Expr."""
+        instance = Expr.__new__(cls)
+        instance._assumptions0 = {}
+        return cast(Reference[U], instance)
+
+    @property
+    def __root_name__(self) -> str:
+        """Root name on which to suffix/prefix any derived names (with fields, etc.).
+
+        For example, the base name of `add_thing-12345[3]` should be `add_thing`.
+
+        Returns: basic name as a string.
+        """
+        raise NotImplementedError(
+            "Reference must have a '__root_name__' property or override '__name__'"
+        )
+
+    @property
+    def __type__(self) -> type:
+        """Type of the reference target, if known."""
+        if self._type is not None:
+            return self._type
+        raise NotImplementedError()
+
+    def _raise_unevaluatable_error(self) -> None:
+        """Convenience method to consistently formulate an UnevaluatableError for this reference."""
+        raise UnevaluatableError(
+            f"This reference, {self.__name__}, cannot be evaluated during construction."
+        )
+
+    def __eq__(self, other: object) -> Any:
+        """Test equality at construct-time, if sensible.
+
+        Raises:
+            UnevaluatableError: if it seems the user is confusing this with a runtime check.
+        """
+        if isinstance(other, list) or other is None:
+            return False
+        if not isinstance(other, Reference) and not isinstance(other, Basic):
+            self._raise_unevaluatable_error()
+        return super().__eq__(other)
+
+    def __float__(self) -> bool:
+        """Catch accidental float casts.
+
+        Raises:
+            UnevaluatableError: unconditionally, as it seems the user is confusing this with a runtime check.
+        """
+        self._raise_unevaluatable_error()
+        return False
+
+    def __int__(self) -> bool:
+        """Catch accidental int casts.
+
+        Raises:
+            UnevaluatableError: unconditionally, as it seems the user is confusing this with a runtime check.
+        """
+        self._raise_unevaluatable_error()
+        return False
+
+    def __bool__(self) -> bool:
+        """Catch accidental bool casts.
+
+        Note that this means ambiguous checks such as `if ref: ...` will error, and should be `if ref is None: ...`
+        or similar.
+
+        Raises:
+            UnevaluatableError: unconditionally, as it seems the user is confusing this with a runtime check.
+        """
+        self._raise_unevaluatable_error()
+        return False
+
+    @property
+    def __name__(self) -> str:
+        """Referral name for this reference.
+
+        Returns: an internal name to refer to the reference target.
+        """
+        workflow = self.__workflow__
+        name = self.__root_name__
+        return workflow.remap(name) if workflow is not None else name
+
+    def __str__(self) -> str:
+        """Global description of the reference.
+
+        Returns the _internal_ name.
+        """
+        return self.__name__
+
+
+class IterableMixin(Reference[U]):
+    """Functionality for iterating over references to give new references."""
+
+    __fixed_len__: int | None = None
+
+    def __init__(self, typ: type[U] | None = None, **kwargs: Any):
+        """Extract length, if available from type.
+
+        Captures types of the form (e.g.) `tuple[int, float]` and records the length
+        as being (e.g.) 2.
+        """
+        super().__init__(typ=typ, **kwargs)
+        base = strip_annotations(self.__type__)[0]
+        if get_origin(base) == tuple and (args := get_args(base)):
+            # In the special case of an explicitly-typed tuple, we can state a length.
+            self.__fixed_len__ = len(args)
+
+    def __len__(self) -> int:
+        """Length of this iterable, if available.
+
+        The two cases that this is likely to be available are if the reference target
+        has been type-hinted as a `tuple` with a specific, fixed number of type arguments,
+        or if the target has been annotated with `Fixed(...)` indicating that the length
+        of the default value can be hard-coded into the output, and therefore that it can
+        be used for graph-building logic. The most useful application of this is likely to
+        be in for-loops and generators, as we can create variable references for each iteration
+        but can nonetheless execute the loop as we know how many iterations occur.
+
+        Returns: length of the iterable, if available.
+        """
+        if self.__fixed_len__ is None:
+            raise TypeError(
+                "This iterable reference does not have a known fixed length, "
+                "consider using `Fixed[...]` with a default, or typehint using `tuple[int, float]` (or similar) "
+                "to tell dewret how long it should be."
+            )
+        return self.__fixed_len__
+
+    def __iter__(self) -> Generator[Reference[U], None, None]:
+        """Execute the iteration.
+
+        Note that this does _not_ return the yielded values of `__inner_iter__`, so that
+        it can be used with impunity to do actual iteration, and we will _always_ return
+        references here.
+
+        Returns: a generator that will give a new reference for every iteration.
+        """
+        for count, _ in enumerate(self.__inner_iter__()):
+            yield super().__getitem__(count)
+
+    def __inner_iter__(self) -> Generator[Any, None, None]:
+        """Overrideable iterator for looping over the wrapped object.
+
+        Returns: a generator that will yield ints if this reference is known to be fixed length, or will go
+        forever yielding None otherwise.
+        """
+        if self.__fixed_len__ is not None:
+            for i in range(self.__fixed_len__):
+                yield i
+        else:
+            while True:
+                yield None
+
+    def __getitem__(self, attr: str | int) -> "Reference[U] | Any":
+        """Get a reference to an individual item/field.
+
+        Args:
+            attr: index or fieldname.
+
+        Returns: a reference to the same target as this reference but a level deeper.
+        """
+        return super().__getitem__(attr)
+
+
+class IteratedGenerator(Generic[U]):
+    """Sentinel value for capturing that an iteration has occured without performing it.
+
+    Allows us to lazily evaluate a loop, for instance, in the renderer. This may be relevant
+    if the renderer wishes to postpone iteration to runtime, and simply record it is required,
+    rather than evaluating the iterator.
+    """
+
+    __wrapped__: Reference[U]
+
+    def __init__(self, to_wrap: Reference[U]):
+        """Capture wrapped reference.
+
+        Args:
+            to_wrap: reference to wrap.
+        """
+        self.__wrapped__ = to_wrap
+
+    def __iter__(self) -> Generator[Reference[U], None, None]:
+        """Loop through the wrapped reference.
+
+        This will tag the references that are returned, so that the renderer can see this has
+        happened.
+
+        Returns: a generator looping over the wrapped reference with a counter as the "field".
+        """
+        count = -1
+        for _ in self.__wrapped__.__inner_iter__():
+            ref = self.__wrapped__[(count := count + 1)]
+            ref.__iterated__ = True
+            yield ref
+
+
+@dataclass
+class Raw:
+    """Value object for any raw types.
+
+    This is able to hash raw types consistently and provides
+    a single type for validating type-consistency.
+
+    Attributes:
+        value: the real value, e.g. a `str`, `int`, ...
+    """
+
+    value: RawType
+
+    def __hash__(self) -> int:
+        """Provide a hash that is unique to the `value` member."""
+        return hash(repr(self))
+
+    def __repr__(self) -> str:
+        """Convert to a consistent, string representation."""
+        value: str
+        if isinstance(self.value, bytes):
+            value = base64.b64encode(self.value).decode("ascii")
+        else:
+            value = str(self.value)
+        return f"{type(self.value).__name__}|{value}"

--- a/src/dewret/core.py
+++ b/src/dewret/core.py
@@ -49,7 +49,7 @@ BasicType = str | float | bool | bytes | int | None
 RawType = BasicType | list["RawType"] | dict[str, "RawType"]
 FirmType = RawType | list["FirmType"] | dict[str, "FirmType"] | tuple["FirmType", ...]
 # Basic is from Sympy, which does not have type annotations, so ExprType cannot pass mypy
-ExprType = (FirmType | Basic | list["ExprType"] | dict[str, "ExprType"] | tuple["ExprType", ...]) # type: ignore # fmt: skip
+ExprType = (FirmType | Basic | list["ExprType"] | dict[str, "ExprType"] | tuple["ExprType", ...])  # type: ignore # fmt: skip
 
 U = TypeVar("U")
 T = TypeVar("T")

--- a/src/dewret/core.py
+++ b/src/dewret/core.py
@@ -48,7 +48,8 @@ import copy
 BasicType = str | float | bool | bytes | int | None
 RawType = BasicType | list["RawType"] | dict[str, "RawType"]
 FirmType = RawType | list["FirmType"] | dict[str, "FirmType"] | tuple["FirmType", ...]
-ExprType = (FirmType | Basic | list["ExprType"] | dict[str, "ExprType"] | tuple["ExprType", ...]) # type: ignore
+# Basic is from Sympy, which does not have type annotations, so ExprType cannot pass mypy
+ExprType = (FirmType | Basic | list["ExprType"] | dict[str, "ExprType"] | tuple["ExprType", ...]) # type: ignore # fmt: skip
 
 U = TypeVar("U")
 T = TypeVar("T")

--- a/src/dewret/render.py
+++ b/src/dewret/render.py
@@ -1,0 +1,147 @@
+# Copyright 2024- Flax & Teal Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for building renderers.
+
+Provides the routines for calling varied renderers in a standard way, and for
+renderers to reuse to build up their own functionality.
+"""
+
+import sys
+from pathlib import Path
+from functools import partial
+from typing import TypeVar, Callable, ContextManager, IO, Any, cast
+import yaml
+
+from .workflow import Workflow, NestedStep
+from .core import (
+    RawType,
+    RenderCall,
+    BaseRenderModule,
+    RawRenderModule,
+    StructuredRenderModule,
+    RenderConfiguration,
+)
+from .utils import load_module_or_package
+
+T = TypeVar("T")
+
+
+def structured_to_raw(rendered: RawType, pretty: bool = False) -> str:
+    """Serialize a serializable structure to a string.
+
+    Args:
+        rendered: a possibly-nested, static basic Python structure.
+        pretty: whether to attempt YAML dumping with an indent of 2.
+
+    Returns: YAML/stringified version of the structure.
+    """
+    if pretty:
+        output = yaml.safe_dump(rendered, indent=2)
+    else:
+        output = str(rendered)
+    return output
+
+
+def get_render_method(
+    renderer: Path | RawRenderModule | StructuredRenderModule, pretty: bool = False
+) -> RenderCall:
+    """Create a ready-made callable to render the workflow that is appropriate for the renderer module.
+
+    Args:
+        renderer: a module or path to a module.
+        pretty: whether the renderer should attempt to YAML-format the output (if relevant).
+
+    Returns: a callable with a consistent interface, regardless of the renderer type.
+    """
+    render_module: BaseRenderModule
+    if isinstance(renderer, Path):
+        # Attempt to load renderer as package, falling back to a single module otherwise.
+        # This enables relative imports in renderers and therefore the ability to modularize.
+        module = load_module_or_package("__renderer__", renderer)
+        sys.modules["__renderer_mod__"] = module
+        render_module = cast(BaseRenderModule, module)
+    else:
+        render_module = renderer
+
+    if isinstance(render_module, RawRenderModule):
+        return render_module.render_raw
+    elif isinstance(render_module, (StructuredRenderModule)):
+
+        def _render(
+            workflow: Workflow,
+            render_module: StructuredRenderModule,
+            pretty: bool = False,
+            **kwargs: RenderConfiguration,
+        ) -> dict[str, str]:
+            rendered = render_module.render(workflow, **kwargs)
+            return {
+                key: structured_to_raw(value, pretty=pretty)
+                for key, value in rendered.items()
+            }
+
+        return cast(
+            RenderCall, partial(_render, render_module=render_module, pretty=pretty)
+        )
+
+    raise NotImplementedError(
+        "This render module neither seems to be a structured nor a raw render module."
+    )
+
+
+def write_rendered_output(
+    rendered: dict[str, str] | dict[str, RawType],
+    output: str,
+    opener: Callable[[str, str], ContextManager[IO[Any]]],
+) -> None:
+    """Utility function to handle writing rendered output to file or stdout."""
+    if len(rendered) == 1:
+        with opener("", "w") as output_f:
+            output_f.write(rendered["__root__"])
+    elif "%" in output:
+        for key, value in rendered.items():
+            if key == "__root__":
+                key = "ROOT"
+            with opener(key, "w") as output_f:
+                output_f.write(value)
+    else:
+        with opener("ROOT", "w") as output_f:
+            output_f.write(rendered["__root__"])
+        del rendered["__root__"]
+        for key, value in rendered.items():
+            with opener(key, "a") as output_f:
+                output_f.write("\n---\n")
+                output_f.write(value)
+
+
+def base_render(workflow: Workflow, build_cb: Callable[[Workflow], T]) -> dict[str, T]:
+    """Render to a dict-like structure.
+
+    Args:
+        workflow: workflow to evaluate result.
+        build_cb: a callback to call for each workflow found.
+
+    Returns:
+        Reduced form as a native Python dict structure for
+        serialization.
+    """
+    primary_workflow = build_cb(workflow)
+    subworkflows = {}
+    for step in workflow.indexed_steps.values():
+        if isinstance(step, NestedStep):
+            nested_subworkflows = base_render(step.subworkflow, build_cb)
+            subworkflows.update(nested_subworkflows)
+            subworkflows[step.name] = nested_subworkflows["__root__"]
+    subworkflows["__root__"] = primary_workflow
+    return subworkflows

--- a/src/dewret/renderers/cwl.py
+++ b/src/dewret/renderers/cwl.py
@@ -19,31 +19,135 @@ current workflow.
 """
 
 from attrs import define, has as attrs_has, fields as attrs_fields, AttrsInstance
-from dataclasses import dataclass, is_dataclass, fields as dataclass_fields
+from dataclasses import is_dataclass, fields as dataclass_fields
 from collections.abc import Mapping
-from contextvars import ContextVar
-from typing import TypedDict, NotRequired, get_args, Union, cast, Any, Iterable, Unpack
+from typing import (
+    TypedDict,
+    NotRequired,
+    get_origin,
+    get_args,
+    cast,
+    Any,
+    Unpack,
+    Iterable,
+)
 from types import UnionType
+from inspect import isclass
+from sympy import Basic, Tuple, Dict, jscode, Symbol
 
+from dewret.core import (
+    Raw,
+    RawType,
+    FirmType,
+)
 from dewret.workflow import (
     FactoryCall,
-    Reference,
-    Raw,
     Workflow,
     BaseStep,
-    NestedStep,
     StepReference,
     ParameterReference,
+    expr_to_references,
+)
+from dewret.utils import (
+    crawl_raw,
+    DataclassProtocol,
+    firm_to_raw,
+    flatten_if_set,
     Unset,
 )
-from dewret.utils import RawType, flatten, DataclassProtocol
-
-InputSchemaType = Union[
-    str, "CommandInputSchema", list[str], list["InputSchemaType"], dict[str, str]
-]
+from dewret.render import base_render
+from dewret.core import Reference, get_render_configuration, set_render_configuration
 
 
-@dataclass
+class CommandInputSchema(TypedDict):
+    """Structure for referring to a raw type in CWL.
+
+    Encompasses several CWL types. In future, it may be best to
+    use _cwltool_ or another library for these basic structures.
+
+    Attributes:
+        type: CWL type of this input.
+        label: name to show for this input.
+        fields: (for `record`) individual fields in a dict-like structure.
+        items: (for `array`) type that each field will have.
+    """
+
+    type: "InputSchemaType"
+    label: str
+    fields: NotRequired[dict[str, "CommandInputSchema"]]
+    items: NotRequired["InputSchemaType"]
+    default: NotRequired[RawType]
+
+
+InputSchemaType = (
+    str
+    | CommandInputSchema
+    | list[str]
+    | list["InputSchemaType"]
+    | dict[str, "str | InputSchemaType"]
+)
+
+
+def render_expression(ref: Any) -> "ReferenceDefinition":
+    """Turn a rich (sympy) expression into a CWL JS expression.
+
+    Args:
+        ref: a structure whose elements are all string-renderable or sympy Basic.
+
+    Returns: a ReferenceDefinition containing a string representation of the expression in the form `$(...)`.
+    """
+
+    def _render(ref: Any) -> Basic | RawType:
+        if not isinstance(ref, Basic):
+            if isinstance(ref, Mapping):
+                ref = Dict({key: _render(val) for key, val in ref.items()})
+            elif not isinstance(ref, str | bytes) and isinstance(ref, Iterable):
+                ref = Tuple(*(_render(val) for val in ref))
+        return ref
+
+    expr = _render(ref)
+    if isinstance(expr, Basic):
+        values = list(expr.free_symbols)
+        step_syms = [sym for sym in expr.free_symbols if isinstance(sym, StepReference)]
+        param_syms = [
+            sym for sym in expr.free_symbols if isinstance(sym, ParameterReference)
+        ]
+
+        if set(values) != set(step_syms) | set(param_syms):
+            raise NotImplementedError(
+                f"Can only build expressions for step results and param results: {ref}"
+            )
+
+        if len(step_syms) > 1:
+            raise NotImplementedError(
+                f"Can only create expressions with 1 step reference: {ref}"
+            )
+        if not (step_syms or param_syms):
+            ...
+        if values == [ref]:
+            if isinstance(ref, StepReference):
+                return ReferenceDefinition(source=to_name(ref), value_from=None)
+            else:
+                return ReferenceDefinition(source=ref.name, value_from=None)
+        source = None
+        for ref in values:
+            if isinstance(ref, StepReference):
+                field = with_field(ref)
+                parts = field.split("/")
+                base = f"/{parts[0]}" if parts and parts[0] else ""
+                if len(parts) > 1:
+                    expr = expr.subs(ref, f"self.{'.'.join(parts[1:])}")
+                else:
+                    expr = expr.subs(ref, "self")
+                source = f"{ref.__root_name__}{base}"
+            else:
+                expr = expr.subs(ref, Symbol(f"inputs.{ref.name}"))
+        return ReferenceDefinition(
+            source=source, value_from=f"$({jscode(_render(expr))})"
+        )
+    return ReferenceDefinition(source=str(expr), value_from=None)
+
+
 class CWLRendererConfiguration(TypedDict):
     """Configuration for the renderer.
 
@@ -56,30 +160,65 @@ class CWLRendererConfiguration(TypedDict):
     factories_as_params: NotRequired[bool]
 
 
-CONFIGURATION: ContextVar[CWLRendererConfiguration] = ContextVar("cwl-configuration")
+def default_config() -> CWLRendererConfiguration:
+    """Default configuration for this renderer.
 
+    This is a hook-like call to give a configuration dict that this renderer
+    will respect, and sets any necessary default values.
 
-def set_configuration(configuration: CWLRendererConfiguration) -> None:
-    """Set configuration for this rendering.
-
-    Args:
-        configuration: overridden settings as dict.
+    Returns: a dict with (preferably) raw type structures to enable easy setting
+        from YAML/JSON.
     """
-    CONFIGURATION.set(
-        CWLRendererConfiguration(
-            allow_complex_types=False,
-            factories_as_params=False,
-        )
-    )
-    CONFIGURATION.get().update(configuration)
+    return {
+        "allow_complex_types": False,
+        "factories_as_params": False,
+    }
 
 
-def configuration(key: str) -> Any:
-    """Retrieve current configuration (thread/async-local)."""
-    current_configuration = CONFIGURATION.get()
-    if key not in current_configuration:
-        raise KeyError("Unknown configuration settings.")
-    return current_configuration.get(key)
+def with_type(result: Any) -> type | Any:
+    """Get a Python type from a value.
+
+    Does so either by using its `__type__` field (for example, for References)
+    or if unavailable, using `type()`.
+
+    Returns: a Python type.
+    """
+    if hasattr(result, "__type__"):
+        return result.__type__
+    return type(result)
+
+
+def with_field(result: Any) -> str:
+    """Get a string representing any 'field' suffix of a value.
+
+    This only makes sense in the context of a Reference, which can represent
+    a deep reference with a known variable (parameter or step result, say) using
+    its `__field__` attribute. Defaults to `"out"` as this produces compliant CWL
+    where every output has a "fieldname".
+
+    Returns: a string representation of the field portion of the passed value or `"out"`.
+    """
+    if hasattr(result, "__field__") and result.__field__:
+        return str(result.__field_str__)
+    else:
+        return "out"
+
+
+def to_name(result: Reference[Any]) -> str:
+    """Take a reference and get a name representing it.
+
+    The primary purpose of this method is to deal with the case where a reference is to the
+    whole result, as we always put this into an imagined `out` field for CWL consistency.
+
+    Returns: the name of the reference, including any field portion, appending an `"out"` fieldname if none.
+    """
+    if (
+        hasattr(result, "__field__")
+        and not result.__field__
+        and isinstance(result, StepReference)
+    ):
+        return f"{result.__name__}/out"
+    return result.__name__
 
 
 @define
@@ -89,10 +228,11 @@ class ReferenceDefinition:
     Normally points to a value or a step.
     """
 
-    source: str
+    source: str | None
+    value_from: str | None
 
     @classmethod
-    def from_reference(cls, ref: Reference) -> "ReferenceDefinition":
+    def from_reference(cls, ref: Reference[Any]) -> "ReferenceDefinition":
         """Build from a `Reference`.
 
         Converts a `dewret.workflow.Reference` into a CWL-rendering object.
@@ -100,7 +240,7 @@ class ReferenceDefinition:
         Args:
             ref: reference to convert.
         """
-        return cls(source=ref.name)
+        return render_expression(ref)
 
     def render(self) -> dict[str, RawType]:
         """Render to a dict-like structure.
@@ -109,7 +249,12 @@ class ReferenceDefinition:
             Reduced form as a native Python dict structure for
             serialization.
         """
-        return {"source": self.source}
+        representation: dict[str, RawType] = {}
+        if self.source is not None:
+            representation["source"] = self.source
+        if self.value_from is not None:
+            representation["valueFrom"] = self.value_from
+        return representation
 
 
 @define
@@ -168,93 +313,94 @@ class StepDefinition:
                 key: (
                     ref.render()
                     if isinstance(ref, ReferenceDefinition)
-                    else {"default": ref.value}
+                    else render_expression(ref).render()
+                    if isinstance(ref, Basic)
+                    else {"default": firm_to_raw(ref.value)}
+                    if hasattr(ref, "value")
+                    else render_expression(ref).render()
                 )
                 for key, ref in self.in_.items()
             },
-            "out": flatten(self.out),
+            "out": crawl_raw(self.out),
         }
 
 
-def cwl_type_from_value(val: RawType | Unset) -> str | list[str] | dict[str, Any]:
+def cwl_type_from_value(label: str, val: RawType | Unset) -> CommandInputSchema:
     """Find a CWL type for a given (possibly Unset) value.
 
     Args:
+        label: the label for the variable being checked to prefill the input def and improve debugging info.
         val: a raw Python variable or an unset variable.
 
     Returns:
-        Type as a string or list of strings.
+        Input schema type.
     """
     if val is not None and hasattr(val, "__type__"):
         raw_type = val.__type__
     else:
         raw_type = type(val)
 
-    return to_cwl_type(raw_type)
+    return to_cwl_type(label, raw_type)
 
 
-def to_cwl_type(typ: type) -> str | dict[str, Any] | list[str]:
+def to_cwl_type(label: str, typ: type) -> CommandInputSchema:
     """Map Python types to CWL types.
 
     Args:
+        label: the label for the variable being checked to prefill the input def and improve debugging info.
         typ: a Python basic type.
 
     Returns:
-        CWL specification type name, or a list
-        if a union.
+        CWL specification type dict.
     """
-    if typ == int:
-        return "int"
-    elif typ == bool:
-        return "boolean"
-    elif typ == dict or attrs_has(typ):
-        return "record"
-    elif typ == float:
-        return "float"
-    elif typ == str:
-        return "string"
-    elif typ == bytes:
-        return "bytes"
-    elif configuration("allow_complex_types"):
-        return typ if isinstance(typ, str) else typ.__name__
+    typ_dict: CommandInputSchema = {"label": label, "type": ""}
+    base: Any | None = typ
+    args = get_args(typ)
+    if args:
+        base = get_origin(typ)
+
+    if base == type(None):
+        typ_dict["type"] = "null"
+    elif base == int:
+        typ_dict["type"] = "int"
+    elif base == bool:
+        typ_dict["type"] = "boolean"
+    elif base == dict or (isinstance(base, type) and attrs_has(base)):
+        typ_dict["type"] = "record"
+    elif base == float:
+        typ_dict["type"] = "float"
+    elif base == str:
+        typ_dict["type"] = "string"
+    elif base == bytes:
+        typ_dict["type"] = "bytes"
     elif isinstance(typ, UnionType):
-        return [to_cwl_type(item) for item in get_args(typ)]
-    elif isinstance(typ, Iterable):
+        typ_dict.update(
+            {"type": tuple(to_cwl_type(label, item)["type"] for item in args)}
+        )
+    elif isclass(base) and issubclass(base, Iterable):
         try:
-            basic_types = get_args(typ)
-            if len(basic_types) > 1:
-                return {
-                    "type": "array",
-                    "items": [{"type": to_cwl_type(t)} for t in basic_types],
-                }
+            if len(args) > 1:
+                typ_dict.update(
+                    {
+                        "type": "array",
+                        "items": [to_cwl_type(label, t)["type"] for t in args],
+                    }
+                )
+            elif len(args) == 1:
+                typ_dict.update(
+                    {"type": "array", "items": to_cwl_type(label, args[0])["type"]}
+                )
             else:
-                return {"type": "array", "items": to_cwl_type(basic_types[0])}
+                typ_dict["type"] = "array"
         except IndexError as err:
             raise TypeError(
-                f"Cannot render complex type ({typ}) to CWL, have you enabled allow_complex_types configuration?"
+                f"Cannot render complex type ({typ}) to CWL for {label}, have you enabled allow_complex_types configuration?"
             ) from err
+    elif get_render_configuration("allow_complex_types"):
+        typ_dict["type"] = typ if isinstance(typ, str) else typ.__name__
     else:
-        raise TypeError(f"Cannot render complex type ({typ}) to CWL")
-
-
-class CommandInputSchema(TypedDict):
-    """Structure for referring to a raw type in CWL.
-
-    Encompasses several CWL types. In future, it may be best to
-    use _cwltool_ or another library for these basic structures.
-
-    Attributes:
-        type: CWL type of this input.
-        label: name to show for this input.
-        fields: (for `record`) individual fields in a dict-like structure.
-        items: (for `array`) type that each field will have.
-    """
-
-    type: InputSchemaType
-    label: str
-    fields: NotRequired[dict[str, "CommandInputSchema"]]
-    items: NotRequired[InputSchemaType]
-    default: NotRequired[RawType]
+        raise TypeError(f"Cannot render type ({typ}) to CWL for {label}")
+    return typ_dict
 
 
 class CommandOutputSchema(CommandInputSchema):
@@ -268,6 +414,8 @@ class CommandOutputSchema(CommandInputSchema):
     """
 
     outputSource: NotRequired[str]
+    expression: NotRequired[str]
+    source: NotRequired[list[str]]
 
 
 def raw_to_command_input_schema(label: str, value: RawType | Unset) -> InputSchemaType:
@@ -286,7 +434,7 @@ def raw_to_command_input_schema(label: str, value: RawType | Unset) -> InputSche
     if isinstance(value, dict) or isinstance(value, list):
         return _raw_to_command_input_schema_internal(label, value)
     else:
-        return cwl_type_from_value(value)
+        return cwl_type_from_value(label, value)
 
 
 def to_output_schema(
@@ -329,9 +477,10 @@ def to_output_schema(
             fields=fields,
         )
     else:
+        # TODO: this complains because NotRequired keys are never present,
+        # but that does not seem like a problem here - likely a better solution.
         output = CommandOutputSchema(
-            type=to_cwl_type(typ),
-            label=label,
+            **to_cwl_type(label, typ)  # type: ignore
         )
     if output_source is not None:
         output["outputSource"] = output_source
@@ -341,8 +490,7 @@ def to_output_schema(
 def _raw_to_command_input_schema_internal(
     label: str, value: RawType | Unset
 ) -> CommandInputSchema:
-    typ = cwl_type_from_value(value)
-    structure: CommandInputSchema = {"type": typ, "label": label}
+    structure: CommandInputSchema = cwl_type_from_value(label, value)
     if isinstance(value, dict):
         structure["fields"] = {
             key: _raw_to_command_input_schema_internal(key, val)
@@ -351,15 +499,20 @@ def _raw_to_command_input_schema_internal(
     elif isinstance(value, list):
         typeset = set(get_args(value))
         if not typeset:
-            typeset = {type(item) for item in value}
+            typeset = {
+                item.__type__
+                if item is not None and hasattr(item, "__type__")
+                else type(item)
+                for item in value
+            }
         if len(typeset) != 1:
             raise RuntimeError(
                 "For CWL, an input array must have a consistent type, "
                 "and we need at least one element to infer it, or an explicit typehint."
             )
-        structure["items"] = to_cwl_type(typeset.pop())
+        structure["items"] = to_cwl_type(label, typeset.pop())["type"]
     elif not isinstance(value, Unset):
-        structure["default"] = value
+        structure["default"] = firm_to_raw(value)
     return structure
 
 
@@ -390,7 +543,7 @@ class InputsDefinition:
 
     @classmethod
     def from_parameters(
-        cls, parameters: list[ParameterReference | FactoryCall]
+        cls, parameters: list[ParameterReference[Any] | FactoryCall]
     ) -> "InputsDefinition":
         """Takes a list of parameters into a CWL structure.
 
@@ -399,13 +552,19 @@ class InputsDefinition:
         Returns:
             CWL-like structure representing all workflow outputs.
         """
+        parameters_dedup = {
+            p._.parameter for p in parameters if isinstance(p, ParameterReference)
+        }
+        parameters = list(parameters_dedup) + [
+            p for p in parameters if not isinstance(p, ParameterReference)
+        ]
         return cls(
             inputs={
                 input.name: cls.CommandInputParameter(
-                    label=input.name,
-                    default=input.default,
+                    label=input.__name__,
+                    default=(default := flatten_if_set(input.__default__)),
                     type=raw_to_command_input_schema(
-                        label=input.name, value=input.default
+                        label=input.__original_name__, value=default
                     ),
                 )
                 for input in parameters
@@ -421,14 +580,11 @@ class InputsDefinition:
         """
         result: dict[str, RawType] = {}
         for key, input in self.inputs.items():
-            item = {
-                # Would rather not cast, but CommandInputSchema is dict[RawType]
-                # by construction, where type is seen as a TypedDict subclass.
-                "type": cast(RawType, input.type),
-                "label": input.label,
-            }
-            if not isinstance(input.default, Unset):
-                item["default"] = input.default
+            # Would rather not cast, but CommandInputSchema is dict[RawType]
+            # by construction, where type is seen as a TypedDict subclass.
+            item = firm_to_raw(cast(FirmType, input.type))
+            if isinstance(item, dict) and not isinstance(input.default, Unset):
+                item["default"] = firm_to_raw(input.default)
             result[key] = item
         return result
 
@@ -443,11 +599,18 @@ class OutputsDefinition:
         outputs: sequence of results from a workflow.
     """
 
-    outputs: dict[str, "CommandOutputSchema"]
+    outputs: (
+        dict[str, "CommandOutputSchema"]
+        | list["CommandOutputSchema"]
+        | CommandOutputSchema
+    )
 
     @classmethod
     def from_results(
-        cls, results: dict[str, StepReference[Any]]
+        cls,
+        results: dict[str, StepReference[Any]]
+        | list[StepReference[Any]]
+        | tuple[StepReference[Any], ...],
     ) -> "OutputsDefinition":
         """Takes a mapping of results into a CWL structure.
 
@@ -456,23 +619,56 @@ class OutputsDefinition:
         Returns:
             CWL-like structure representing all workflow outputs.
         """
-        return cls(
-            outputs={
-                key: to_output_schema(
-                    result.field, result.return_type, output_source=result.name
-                )
-                for key, result in results.items()
-            }
-        )
 
-    def render(self) -> dict[str, RawType]:
+        def _build_results(result: Any) -> RawType:
+            if isinstance(result, Reference):
+                # TODO: need to work out how to tell mypy that a TypedDict is also dict[str, RawType]
+                return to_output_schema(  # type: ignore
+                    with_field(result), with_type(result), output_source=to_name(result)
+                )
+            results = result
+            return (
+                [_build_results(result) for result in results]
+                if isinstance(results, list | tuple | Tuple)
+                else {key: _build_results(result) for key, result in results.items()}
+            )
+
+        try:
+            # TODO: sort out this nested type building.
+            return cls(outputs=_build_results(results))  # type: ignore
+        except AttributeError:
+            expr, references = expr_to_references(results)
+            reference_names = sorted(
+                {
+                    str(ref._.parameter)
+                    if isinstance(ref, ParameterReference)
+                    else str(ref._.step)
+                    for ref in references
+                }
+            )
+            return cls(
+                outputs={
+                    "out": {
+                        "type": "float",  # WARNING: we assume any arithmetic expression returns a float.
+                        "label": "out",
+                        "expression": str(expr),
+                        "source": reference_names,
+                    }
+                }
+            )
+
+    def render(self) -> dict[str, RawType] | list[RawType]:
         """Render to a dict-like structure.
 
         Returns:
             Reduced form as a native Python dict structure for
             serialization.
         """
-        return {key: flatten(output) for key, output in self.outputs.items()}
+        return (
+            [crawl_raw(output) for output in self.outputs]
+            if isinstance(self.outputs, list)
+            else {key: crawl_raw(output) for key, output in self.outputs.items()}
+        )
 
 
 @define
@@ -503,25 +699,31 @@ class WorkflowDefinition:
             workflow: workflow to convert.
             name: name of this workflow, if it should have one.
         """
-        parameters: list[ParameterReference | FactoryCall] = list(
+        parameters: list[ParameterReference[Any] | FactoryCall] = list(
             workflow.find_parameters(
-                include_factory_calls=not configuration("factories_as_params")
+                include_factory_calls=not get_render_configuration(
+                    "factories_as_params"
+                )
             )
         )
-        if configuration("factories_as_params"):
+        if get_render_configuration("factories_as_params"):
             parameters += list(workflow.find_factories().values())
         return cls(
             steps=[
                 StepDefinition.from_step(step)
-                for step in workflow.steps
+                for step in workflow.indexed_steps.values()
                 if not (
                     isinstance(step, FactoryCall)
-                    and configuration("factories_as_params")
+                    and get_render_configuration("factories_as_params")
                 )
             ],
             inputs=InputsDefinition.from_parameters(parameters),
             outputs=OutputsDefinition.from_results(
-                {workflow.result.field: workflow.result} if workflow.result else {}
+                workflow.result
+                if isinstance(workflow.result, list | tuple | Tuple)
+                else {with_field(workflow.result): workflow.result}
+                if workflow.has_result and workflow.result is not None
+                else {}
             ),
             name=name,
         )
@@ -544,7 +746,7 @@ class WorkflowDefinition:
 
 def render(
     workflow: Workflow, **kwargs: Unpack[CWLRendererConfiguration]
-) -> dict[str, RawType] | tuple[dict[str, RawType], dict[str, dict[str, RawType]]]:
+) -> dict[str, dict[str, RawType]]:
     """Render to a dict-like structure.
 
     Args:
@@ -555,16 +757,10 @@ def render(
         Reduced form as a native Python dict structure for
         serialization.
     """
-    set_configuration(kwargs)
-    primary_workflow = WorkflowDefinition.from_workflow(workflow).render()
-    subworkflows = {}
-    for step in workflow.steps:
-        if isinstance(step, NestedStep):
-            subworkflows[step.name] = WorkflowDefinition.from_workflow(
-                step.subworkflow
-            ).render()
-
-    if subworkflows:
-        return primary_workflow, subworkflows
-
-    return primary_workflow
+    # TODO: Again, convincing mypy that a TypedDict has RawType values.
+    with set_render_configuration(kwargs):  # type: ignore
+        rendered = base_render(
+            workflow,
+            lambda workflow: WorkflowDefinition.from_workflow(workflow).render(),
+        )
+    return rendered

--- a/src/dewret/utils.py
+++ b/src/dewret/utils.py
@@ -20,13 +20,20 @@ General types and functions to centralize common logic.
 import hashlib
 import json
 import sys
-from types import FrameType, TracebackType
-from typing import Any, cast, Union, Protocol, ClassVar
+import importlib
+import importlib.util
+from types import FrameType, TracebackType, UnionType, ModuleType
+from typing import Any, cast, Protocol, ClassVar, Callable, Iterable, get_args, Hashable
+from pathlib import Path
 from collections.abc import Sequence, Mapping
+from dataclasses import asdict, is_dataclass
+from sympy import Basic, Integer, Float, Rational
 
-BasicType = str | float | bool | bytes | int | None
-RawType = Union[BasicType, list["RawType"], dict[str, "RawType"]]
-FirmType = BasicType | list["FirmType"] | dict[str, "FirmType"] | tuple["FirmType", ...]
+from .core import Reference, RawType, FirmType, Raw
+
+
+class Unset:
+    """Unset variable, with no default value."""
 
 
 class DataclassProtocol(Protocol):
@@ -55,34 +62,136 @@ def make_traceback(skip: int = 2) -> TracebackType | None:
         frame = frame.f_back
     return tb
 
+def load_module_or_package(target_name: str, path: Path) -> ModuleType:
+    """Convenience loader for modules.
 
-def flatten(value: Any) -> RawType:
+    If an `__init__.py` is found in the same location as the target, it will try to load the renderer module
+    as if it is contained in a package and, if it cannot, will fall back to loading the single file.
+
+    Args:
+        target_name: module name that should appear in `sys.modules`.
+        path: location of the module.
+
+    Returns: the loaded module.
+    """
+    module: None | ModuleType = None
+    exception: None | Exception = None
+    package_init = path.parent / "__init__.py"
+    # Try to import the module as a package, if possible, to allow relative imports.
+    if package_init.exists():
+        try:
+            spec = importlib.util.spec_from_file_location(target_name, str(package_init))
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not open {path.parent} package")
+            package = importlib.util.module_from_spec(spec)
+            sys.modules[target_name] = package
+            spec.loader.exec_module(package)
+            module = importlib.import_module(f"{target_name}.{path.stem}", target_name)
+        except ImportError as exc:
+            exception = exc
+
+    if module is None:
+        try:
+            spec = importlib.util.spec_from_file_location(target_name, str(path))
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not open {path} module")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        except ImportError as exc:
+            if exception:
+                 raise exc from exception
+            raise exc
+
+    return module
+
+def flatten_if_set(value: Any) -> RawType | Unset:
+    """Takes a Raw-like structure and makes it RawType or Unset.
+
+    Flattens if the value is set, but otherwise returns the unset
+    sentinel value as-is.
+
+    Args:
+        value: value to squash
+    """
+    if isinstance(value, Unset):
+        return value
+    return crawl_raw(value)
+
+def crawl_raw(value: Any, action: Callable[[Any], Any] | None = None) -> RawType:
     """Takes a Raw-like structure and makes it RawType.
 
     Particularly useful for squashing any TypedDicts.
 
     Args:
         value: value to squash
+        action: an callback to apply to each found entry, or None.
+
+    Returns: a structuure that is guaranteed to be raw.
+
+    Raises: RuntimeError if it cannot convert the value to raw.
     """
+    if action is not None:
+        value = action(value)
+
     if value is None:
         return value
     if isinstance(value, str) or isinstance(value, bytes):
         return value
     if isinstance(value, Mapping):
-        return {key: flatten(item) for key, item in value.items()}
+        return {key: crawl_raw(item, action) for key, item in value.items()}
+    if is_dataclass(value) and not isinstance(value, type):
+        return crawl_raw(asdict(value), action)
     if isinstance(value, Sequence):
-        return [flatten(item) for item in value]
+        return [crawl_raw(item, action) for item in value]
     if (raw := ensure_raw(value)) is not None:
         return raw
     raise RuntimeError(f"Could not flatten: {value}")
 
+def firm_to_raw(value: FirmType) -> RawType:
+    """Convenience wrapper for firm structures.
+
+    Turns structures that would be raw, except for tuples, into raw structures
+    by mapping any tuples to lists.
+
+    Args:
+        value: a firm structure (contains raw/tuple values).
+
+    Returns: a raw structure.
+    """
+    return crawl_raw(value, lambda entry: list(entry) if isinstance(entry, tuple) else entry)
+
+def is_expr(value: Any, permitted_references: type=Reference) -> bool:
+    """Confirms whether a structure has only raw or expression types.
+
+    Args:
+        value: a crawlable structure.
+        permitted_references: a class representing the allowed types of References.
+
+    Returns: True if valid, otherwise False.
+    """
+    return is_raw(value, lambda x: isinstance(x, Basic) or isinstance(x, tuple) or isinstance(x, permitted_references) or isinstance(x, Raw))
 
 def is_raw_type(typ: type) -> bool:
     """Check if a type counts as "raw"."""
+    if isinstance(typ, UnionType):
+        return all(is_raw_type(t) for t in get_args(typ))
     return issubclass(typ, str | float | bool | bytes | int | None | list | dict)
 
 
-def is_raw(value: Any) -> bool:
+def is_firm(value: Any, check: Callable[[Any], bool] | None = None) -> bool:
+    """Confirms whether a function is firm.
+
+    That is, whether its contents are raw or tuples.
+
+    Args:
+        value: value to check.
+        check: any additional check to apply.
+
+    Returns: True if is firm, else False.
+    """
+    return is_raw(value, lambda x: isinstance(x, tuple) and (check is None or check(x)))
+
+def is_raw(value: Any, check: Callable[[Any], bool] | None = None) -> bool:
     """Check if a variable counts as "raw".
 
     This works around a checking issue that isinstance of a union of types
@@ -92,10 +201,29 @@ def is_raw(value: Any) -> bool:
     # Ideally this would be:
     # isinstance(value, RawType | list[RawType] | dict[str, RawType])
     # but recursive types are problematic.
-    return isinstance(value, str | float | bool | bytes | int | None | list | dict)
+    if isinstance(value, str | float | bool | bytes | int | None | Integer | Float | Rational):
+        return True
+
+    if check is not None and check(value):
+        return True
+
+    if isinstance(value, Mapping):
+        return (
+            (isinstance(value, dict) or (check is not None and check(value))) and
+            all(is_raw(key, check) for key in value.keys()) and
+            all(is_raw(val, check) for val in value.values())
+        )
+
+    if isinstance(value, Iterable):
+        return (
+            (isinstance(value, list) or (check is not None and check(value))) and
+            all(is_raw(key, check) for key in value)
+        )
+
+    return False
 
 
-def ensure_raw(value: Any) -> RawType | None:
+def ensure_raw(value: Any, cast_tuple: bool = False) -> RawType | None:
     """Check if a variable counts as "raw".
 
     This works around a checking issue that isinstance of a union of types
@@ -120,13 +248,23 @@ def hasher(construct: FirmType) -> str:
         Hash string that should be unique to the construct. The limits of this uniqueness
         have not yet been explicitly calculated.
     """
-    if isinstance(construct, Sequence) and not isinstance(construct, bytes | str):
-        if isinstance(construct, dict):
-            construct = list([k, hasher(v)] for k, v in sorted(construct.items()))
-        else:
-            # Cast to workaround recursive type
-            construct = cast(FirmType, list(construct))
-    construct_as_string = json.dumps(construct)
+    def _make_hashable(construct: FirmType) -> Hashable:
+        hashed_construct: tuple[Hashable, ...]
+        if isinstance(construct, Sequence) and not isinstance(construct, bytes | str):
+            if isinstance(construct, Mapping):
+                hashed_construct = tuple((k, hasher(v)) for k, v in sorted(construct.items()))
+            else:
+                # Cast to workaround recursive type
+                hashed_construct = tuple(_make_hashable(v) for v in construct)
+            return hashed_construct
+        if not isinstance(construct, Hashable):
+            raise TypeError("Could not hash arguments")
+        return construct
+    if isinstance(construct, Hashable):
+        hashed_construct = construct
+    else:
+        hashed_construct = _make_hashable(construct)
+    construct_as_string = json.dumps(hashed_construct)
     hsh = hashlib.md5()
     hsh.update(construct_as_string.encode())
     return hsh.hexdigest()

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -928,7 +928,11 @@ class FieldableMixin(_Fieldable):
                     type_hints = get_type_hints(parent_type, localns={parent_type.__name__: parent_type}, include_extras=True)
                     field_type = type_hints.get(field)
                     if field_type is None:
-                        field_type = next(iter(filter(lambda fld: fld.name == field, dataclass_fields(parent_type)))).type
+                        dataclass_field_type = next(iter(filter(lambda fld: fld.name == field, dataclass_fields(parent_type)))).type
+                        if isinstance(dataclass_field_type, str):
+                            # TODO: we could ask Python to resolve the str expression for us
+                            raise TypeError("Dataclass fields must be provided as types directly, not str")
+                        field_type = dataclass_field_type
                 except StopIteration:
                     raise AttributeError(f"Dataclass {parent_type} does not have field {field}") from None
             elif attr_has(parent_type):

--- a/src/dewret/workflow.py
+++ b/src/dewret/workflow.py
@@ -20,48 +20,29 @@ Basic constructs for describing a workflow.
 from __future__ import annotations
 import inspect
 from collections.abc import Mapping, MutableMapping, Callable
-import base64
-from attrs import define, has as attr_has, resolve_types, fields as attrs_fields
+from attrs import has as attr_has, resolve_types, fields as attrs_fields
 from dataclasses import is_dataclass, fields as dataclass_fields
-from collections import Counter
-from typing import Protocol, Any, TypeVar, Generic, cast, Literal
+from collections import Counter, OrderedDict
+from typing import Protocol, Any, TypeVar, Generic, cast, Literal, Iterable, get_origin, get_args, Generator, Sized, Sequence, get_type_hints, TYPE_CHECKING, Hashable
 from uuid import uuid4
-
 import logging
+
+from sympy import Symbol, Expr, Basic, Tuple
 
 logger = logging.getLogger(__name__)
 
-from .utils import hasher, RawType, is_raw, make_traceback, is_raw_type
+from .core import IterableMixin, Reference, get_configuration, Raw, IteratedGenerator, strip_annotations, WorkflowProtocol, WorkflowComponent, ExprType
+from .utils import hasher, is_raw, make_traceback, is_raw_type, is_expr, Unset
 
 T = TypeVar("T")
+U = TypeVar("U")
 RetType = TypeVar("RetType")
 
-
-@define
-class Raw:
-    """Value object for any raw types.
-
-    This is able to hash raw types consistently and provides
-    a single type for validating type-consistency.
-
-    Attributes:
-        value: the real value, e.g. a `str`, `int`, ...
-    """
-
-    value: RawType
-
-    def __hash__(self) -> int:
-        """Provide a hash that is unique to the `value` member."""
-        return hash(repr(self))
-
-    def __repr__(self) -> str:
-        """Convert to a consistent, string representation."""
-        value: str
-        if isinstance(self.value, bytes):
-            value = base64.b64encode(self.value).decode("ascii")
-        else:
-            value = str(self.value)
-        return f"{type(self.value).__name__}|{value}"
+CHECK_IDS = False
+AVAILABLE_TYPES = {
+    "int": int,
+    "str": str
+}
 
 
 class Lazy(Protocol):
@@ -106,10 +87,6 @@ StepExecution = Callable[..., Lazy]
 LazyFactory = Callable[[Target], Lazy]
 
 
-class Unset:
-    """Unset variable, with no default value."""
-
-
 class UnsetType(Unset, Generic[T]):
     """Unset variable with a specific type.
 
@@ -131,7 +108,8 @@ class UnsetType(Unset, Generic[T]):
 UNSET = Unset()
 
 
-class Parameter(Generic[T]):
+
+class Parameter(Generic[T], Symbol):
     """Global parameter.
 
     Independent parameter that will be used when a task is spotted
@@ -146,9 +124,10 @@ class Parameter(Generic[T]):
     """
 
     __name__: str
+    __name_suffix__: str = ""
     __default__: T | UnsetType[T]
     __tethered__: Literal[False] | None | BaseStep | Workflow
-
+    __fixed_type__: type[T] | Unset
     autoname: bool = False
 
     def __init__(
@@ -157,6 +136,7 @@ class Parameter(Generic[T]):
         default: T | UnsetType[T],
         tethered: Literal[False] | None | Step | Workflow = None,
         autoname: bool = False,
+        typ: type[T] | Unset = UNSET
     ):
         """Construct a parameter.
 
@@ -165,19 +145,47 @@ class Parameter(Generic[T]):
             default: value to infer type, etc. from.
             tethered: a workflow or step that demands this parameter; None if not yet present, False if not desired.
             autoname: whether we should customize this name for uniqueness (it is not user-set).
+            typ: a type to override what would be automatically inferred.
         """
         self.__original_name__ = name
 
         # TODO: is using this in a step hash a risk of ambiguity? (full name is circular)
         if autoname:
-            name = f"{name}-{uuid4()}"
+            self.__name_suffix__ = f"-{uuid4()}"
         self.autoname = autoname
 
         self.__name__ = name
         self.__default__ = default
         self.__tethered__ = tethered
         self.__callers__: list[BaseStep] = []
+        self.__fixed_type__ = typ
 
+        if tethered and isinstance(tethered, BaseStep):
+            self.register_caller(tethered)
+
+    @staticmethod
+    def is_loopable(typ: type) -> bool:
+        """Checks if this type can be looped over.
+
+        In particular, checks if this is an iterable that is NOT a str or bytes, possibly disguised
+        behind an Annotated.
+
+        Args:
+            typ: type to check.
+
+        Returns: True if loopable, otherwise False.
+        """
+        base = strip_annotations(typ)[0]
+        base = get_origin(base) or base
+        return inspect.isclass(base) and issubclass(base, Iterable) and not issubclass(base, str | bytes)
+
+    @property
+    def __type__(self) -> type | Unset:
+        """Type associated with this parameter."""
+        if self.__fixed_type__ is not UNSET:
+            return self.__fixed_type__
+
+        default = self.__default__
         if (
             default is not None
             and hasattr(default, "__type__")
@@ -186,18 +194,53 @@ class Parameter(Generic[T]):
             raw_type = default.__type__
         else:
             raw_type = type(default)
-        self.__type__: type[T] = raw_type
+        return raw_type
 
-        if tethered and isinstance(tethered, BaseStep):
-            self.register_caller(tethered)
+    def __eq__(self, other: object) -> bool:
+        """Comparing two parameters.
+
+        Currently, this uses the hashes.
+
+        TODO: confirm this is an iff.
+        """
+        return hash(self) == hash(other)
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Parameter[T]":
+        """Creates a Parameter.
+
+        Required, as Parameters are an instance of sympy Expression, so
+        we must instantiate via it.
+        """
+        instance = Expr.__new__(cls)
+        instance._assumptions0 = {}
+        return cast(Parameter[T], instance)
 
     def __hash__(self) -> int:
         """Get a unique hash for this parameter."""
-        if self.__tethered__ is None:
-            raise RuntimeError(
-                "Parameter {self.full_name} was never tethered but should have been"
-            )
+        # if self.__tethered__ is None:
+        #     raise RuntimeError(
+        #         f"Parameter {self.name} was never tethered but should have been"
+        #     )
         return hash(self.__name__)
+
+    def make_reference(self, **kwargs: Any) -> "ParameterReference[T]":
+        """Creates a new reference for the parameter.
+
+        The kwargs will be passed to the constructor, but the 
+
+        Args:
+            typ: type of the new reference's target.
+            **kwargs: arguments to pass to the constructor.
+
+        Returns: checks if `typ` is loopable and gives an IterableParameterReference if so,
+            otherwise a normal ParameterReference.
+        """
+        kwargs["parameter"] = self
+        kwargs.setdefault("typ", self.__type__)
+        typ = kwargs["typ"]
+        if self.is_loopable(typ):
+            return IterableParameterReference(**kwargs)
+        return ParameterReference(**kwargs)
 
     @property
     def default(self) -> T | UnsetType[T]:
@@ -205,7 +248,7 @@ class Parameter(Generic[T]):
         return self.__default__
 
     @property
-    def full_name(self) -> str:
+    def name(self) -> str:
         """Extended name, suitable for rendering.
 
         This attempts to create a unique name by tying the parameter to a step
@@ -214,7 +257,7 @@ class Parameter(Generic[T]):
         """
         tethered = self.__tethered__
         if tethered is False or tethered is None or self.autoname is False:
-            return self.__name__
+            return self.__name__ + self.__name_suffix__
         else:
             return f"{tethered.name}-{self.__original_name__}"
 
@@ -228,14 +271,15 @@ class Parameter(Generic[T]):
             self.__tethered__ = caller
         self.__callers__.append(caller)
 
-    @property
-    def name(self) -> str:
-        """Name for this step.
+    def __getattr__(self, attr: str) -> Reference[T] | Any:
+        """Retrieve a reference to a field within this Parameter.
 
-        May be remapped by the workflow to something nicer
-        than the ID.
+        Arg:
+            attr: a field to find.
+
+        Returns: a new reference with the `attr` appended to the field tuple.
         """
-        return self.full_name
+        return getattr(self.make_reference(workflow=None), attr)
 
 
 def param(
@@ -257,7 +301,7 @@ def param(
             raise ValueError("Must provide a default or a type")
         default = UnsetType[T](typ)
     return cast(
-        T, Parameter(name, default=default, tethered=tethered, autoname=autoname)
+        T, Parameter(name, default=default, tethered=tethered, autoname=autoname, typ=typ)
     )
 
 
@@ -328,19 +372,27 @@ class Workflow:
         result: target reference to evaluate, if yet present.
     """
 
-    steps: list["BaseStep"]
+    _steps: list["BaseStep"]
     tasks: MutableMapping[str, "Task"]
-    result: StepReference[Any] | None
+    result: StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any], ...] | None
     _remapping: dict[str, str] | None
     _name: str | None
 
     def __init__(self, name: str | None = None) -> None:
         """Initialize a Workflow, by setting `steps` and `tasks` to empty containers."""
-        self.steps = []
+        self._steps = []
         self.tasks = {}
         self.result: StepReference[Any] | None = None
         self._remapping = None
         self._name = name
+
+    @property
+    def steps(self) -> set[BaseStep]:
+        """Get deduplicated steps.
+
+        Returns: steps for looping over without duplicates.
+        """
+        return set(self._steps)
 
     def __str__(self) -> str:
         """Name of the workflow, if available."""
@@ -348,9 +400,27 @@ class Workflow:
             return super().__str__()
         return self.name
 
+    def __repr__(self) -> str:
+        """Representation of the workflow.
+
+        This will be the `id` if the workflow is anonymous.
+
+        Returns: string identifier for this workflow.
+        """
+        if self._name:
+            return self.name
+        return self.id
+
     def __hash__(self) -> int:
         """Hashes for finding."""
-        return hash(self.name)
+        return hash(self.id)
+
+    @property
+    def id(self) -> str:
+        """Consistent ID based off the step IDs."""
+        comp_tup = tuple(sorted(s.id for s in self.steps))
+        return f"workflow-{hasher(comp_tup)}"
+
 
     def __eq__(self, other: object) -> bool:
         """Is this the same workflow?
@@ -361,12 +431,22 @@ class Workflow:
         if not isinstance(other, Workflow):
             return False
         return (
-            self.steps == other.steps
+            self._steps == other._steps
             and self.tasks == other.tasks
             and self.result == other.result
             and self._remapping == other._remapping
             and self._name == other._name
         )
+
+    @property
+    def has_result(self) -> bool:
+        """Confirms whether this workflow has a non-empty result.
+
+        Either None or an empty list/tuple are considered empty for this purpose.
+
+        Returns: True if the workflow has a result, False otherwise.
+        """
+        return not(self.result is None or (isinstance(self.result, list | tuple) and not self.result))
 
     @property
     def name(self) -> str:
@@ -381,11 +461,11 @@ class Workflow:
 
     def find_factories(self) -> dict[str, FactoryCall]:
         """Steps that are factory calls."""
-        return {step.id: step for step in self.steps if isinstance(step, FactoryCall)}
+        return {step_id: step for step_id, step in self.indexed_steps.items() if isinstance(step, FactoryCall)}
 
     def find_parameters(
         self, include_factory_calls: bool = True
-    ) -> set[ParameterReference]:
+    ) -> set[Parameter[Any]]:
         """Crawl steps for parameter references.
 
         As the workflow does not hold its own list of parameters, this
@@ -394,22 +474,13 @@ class Workflow:
         Returns:
             Set of all references to parameters across the steps.
         """
-        return set().union(
-            *(
-                {
-                    arg
-                    for arg in step.arguments.values()
-                    if (
-                        isinstance(arg, ParameterReference)
-                        and (include_factory_calls or not isinstance(step, FactoryCall))
-                    )
-                }
-                for step in self.steps
-            )
+        _, references = expr_to_references(
+            step.arguments for step in self.steps if (include_factory_calls or not isinstance(step, FactoryCall))
         )
+        return {ref._.parameter for ref in references if isinstance(ref, ParameterReference)}
 
     @property
-    def _indexed_steps(self) -> dict[str, BaseStep]:
+    def indexed_steps(self) -> dict[str, BaseStep]:
         """Steps mapped by ID.
 
         Forces generation of IDs. Note that this effectively
@@ -419,10 +490,10 @@ class Workflow:
         Returns:
             Mapping of steps by ID.
         """
-        return {step.id: step for step in self.steps}
+        return OrderedDict(sorted(((step.id, step) for step in self.steps), key=lambda x: x[0]))
 
     @classmethod
-    def assimilate(cls, left: Workflow, right: Workflow) -> "Workflow":
+    def assimilate(cls, *workflow_args: Workflow) -> "Workflow":
         """Combine two Workflows into one Workflow.
 
         Takes two workflows and unifies them by combining steps
@@ -431,53 +502,73 @@ class Workflow:
         This could happen if the hashing function is flawed
         or some Python magic to do with Targets being passed.
 
-        Argument:
-            left: workflow to use as base
-            right: workflow to combine on top
+        Args:
+            workflow_args: workflows to use as base
+
+        j
         """
-        new = cls()
+        workflows = sorted((w for w in set(workflow_args)), key=lambda w: w.id)
+        base = workflows[0]
 
-        new._name = left._name or right._name
+        if len(workflows) == 1:
+            return base
 
-        left_steps = left._indexed_steps
-        right_steps = right._indexed_steps
+        names = sorted({w._name for w in workflows if w._name})
+        base._name = base._name or (names and names[0]) or None
 
-        for step in list(left_steps.values()) + list(right_steps.values()):
-            step.set_workflow(new)
-            for arg in step.arguments:
-                if hasattr(arg, "__workflow__"):
-                    arg.__workflow__ = new
+        #left_steps = left._indexed_steps
+        #right_steps = right._indexed_steps
+        all_steps = sorted(sum((list(w.indexed_steps.items()) for w in workflows), []), key=lambda s: s[0])
 
-        for step_id in left_steps.keys() & right_steps.keys():
-            if left_steps[step_id] != right_steps[step_id]:
+        for _, step in all_steps:
+        #for step in list(left_steps.values()) + list(right_steps.values()):
+            step.set_workflow(base)
+
+        indexed_steps: dict[str, BaseStep] = {}
+        for step_id, step in all_steps:
+            indexed_steps.setdefault(step_id, step)
+            if step != indexed_steps[step_id]:
                 raise RuntimeError(
                     f"Two steps have same ID but do not match: {step_id}"
                 )
 
-        for task_id in left.tasks.keys() & right.tasks.keys():
-            if left.tasks[task_id] != right.tasks[task_id]:
-                raise RuntimeError("Two tasks have same name but do not match")
+        all_tasks = sum((list(w.tasks.items()) for w in workflows), [])
+        indexed_tasks: dict[str, Task] = {}
+        for task_id, task in all_tasks:
+            indexed_tasks.setdefault(task_id, task)
+            if task != indexed_tasks[task_id]:
+                raise RuntimeError(f"Two tasks have same name {task_id} but do not match")
 
-        indexed_steps = dict(left_steps)
-        indexed_steps.update(right_steps)
-        new.steps += list(indexed_steps.values())
-        new.tasks.update(left.tasks)
-        new.tasks.update(right.tasks)
+        base._steps = sorted(indexed_steps.values(), key=lambda s: s.id)
+        base.tasks = indexed_tasks
 
-        for step in new.steps:
-            step.set_workflow(new, with_arguments=True)
+        for step in base.steps:
+            step.set_workflow(base, with_arguments=True)
 
-        # TODO: should we combine as a result array?
-        result = left.result or right.result
+        hashable_workflows: list[Workflow] = [w for w in workflows if isinstance(w.result, Hashable)]
+        if len(hashable_workflows) != len(workflows):
+            raise NotImplementedError("Some results are not hashable.")
 
-        if result:
-            new.set_result(
-                StepReference(
-                    new, result.step, typ=result.return_type, field=result.field
-                )
-            )
+        def _get_order(result: None | StepReference[Any] | Iterable[StepReference[Any]]) -> str:
+            if result is None:
+                return ""
+            if isinstance(result, StepReference):
+                return result.id
+            return "|".join(r for r in result)
 
-        return new
+
+        results = sorted(set({w.result for w in hashable_workflows if w.has_result}), key=lambda r: _get_order(r))
+        if len(results) == 1:
+            result = results[0]
+        else:
+            list_results = [r if isinstance(r, tuple | list | Tuple) else (r,) for r in results]
+            result = sum(map(list, list_results), [])
+
+        if result is not None and result != []:
+            unify_workflows(result, base, set_only=True)
+            base.set_result(result)
+
+        return base
 
     def remap(self, step_id: str) -> str:
         """Apply name simplification if requested.
@@ -498,7 +589,7 @@ class Workflow:
         counter = Counter[Task | Workflow]()
         self._remapping = {}
         infix_str = ("-".join(infix) + "-") if infix else ""
-        for step in self.steps:
+        for step in self.indexed_steps.values():
             counter[step.task] += 1
             self._remapping[step.id] = f"{step.task}-{infix_str}{counter[step.task]}"
             if isinstance(step, NestedStep):
@@ -508,9 +599,9 @@ class Workflow:
         param_counter = Counter[str]()
         name_to_original: dict[str, str] = {}
         for name, param in {
-            pr.parameter.__name__: pr.parameter
-            for pr in self.find_parameters()
-            if isinstance(pr, ParameterReference)
+            param.__name__: param
+            for param in self.find_parameters()
+            if isinstance(param, Parameter)
         }.items():
             if param.__original_name__ != name:
                 param_counter[param.__original_name__] += 1
@@ -541,7 +632,7 @@ class Workflow:
         return task
 
     def add_nested_step(
-        self, name: str, subworkflow: Workflow, kwargs: dict[str, Any]
+        self, name: str, subworkflow: Workflow, return_type: type | None, kwargs: dict[str, Any], positional_args: dict[str, bool] | None = None
     ) -> StepReference[Any]:
         """Append a nested step.
 
@@ -550,21 +641,28 @@ class Workflow:
         Args:
             name: name of the subworkflow.
             subworkflow: the subworkflow itself.
+            return_type: a forced type for the return, or None.
             kwargs: any key-value arguments to pass in the call.
+            positional_args: a mapping of arguments to bools, True if the argument is positional or otherwise False.
+
+        Returns: a reference to the step that calls out to a new workflow.
         """
         step = NestedStep(self, name, subworkflow, kwargs)
-        self.steps.append(step)
-        return_type = step.return_type
+        if positional_args is not None:
+            step.positional_args = positional_args
+        self._steps.append(step)
+        return_type = return_type or step.return_type
         if return_type is inspect._empty:
             raise TypeError("All tasks should have a type annotation.")
-        return StepReference(self, step, return_type)
+        return step.make_reference(workflow=self, typ=return_type)
 
     def add_step(
         self,
         fn: Lazy,
-        kwargs: dict[str, Raw | Reference],
+        kwargs: dict[str, Raw | Reference[Any]],
         raw_as_parameter: bool = False,
         is_factory: bool = False,
+        positional_args: dict[str, bool] | None = None
     ) -> StepReference[Any]:
         """Append a step.
 
@@ -576,11 +674,14 @@ class Workflow:
             kwargs: any key-value arguments to pass in the call.
             raw_as_parameter: whether to turn any discovered raw arguments into workflow parameters.
             is_factory: whether this step should be a Factory.
+            positional_args: a mapping of arguments to bools, True if the argument is positional or otherwise False.
         """
         task = self.register_task(fn)
         step_maker = FactoryCall if is_factory else Step
         step = step_maker(self, task, kwargs, raw_as_parameter=raw_as_parameter)
-        self.steps.append(step)
+        if positional_args is not None:
+            step.positional_args = positional_args
+        self._steps.append(step)
         return_type = step.return_type
         if (
             return_type is inspect._empty
@@ -588,23 +689,38 @@ class Workflow:
             and not inspect.isclass(fn)
         ):
             raise TypeError("All tasks should have a type annotation.")
-        return StepReference(self, step, return_type)
+        return step.make_reference(workflow=self, typ=return_type)
 
     @staticmethod
     def from_result(
-        result: StepReference[Any], simplify_ids: bool = False, nested: bool = True
+        result: StepReference[Any] | list[StepReference[Any]] | tuple[StepReference[Any], ...], simplify_ids: bool = False, nested: bool = True
     ) -> Workflow:
         """Create from a desired result.
 
         Starts from a result, and builds a workflow to output it.
         """
-        workflow = result.__workflow__
-        workflow.set_result(result)
+        expr, _refs = expr_to_references(result)
+        if not _refs:
+            raise RuntimeError(
+                "Attempted to build a workflow from a return-value/result/expression with no references."
+            )
+        refs = list(_refs)
+        if isinstance(refs[0], Parameter):
+            raise RuntimeError("Attempted to build a workflow from an input parameter.")
+        workflow = refs[0].__workflow__
+        # Ensure that we have exactly one workflow, even if multiple results.
+        for entry in refs[1:]:
+            if entry.__workflow__ != workflow:
+                raise RuntimeError("If multiple results, they must share a single workflow")
+        workflow.set_result(expr)
         if simplify_ids:
             workflow.simplify_ids()
+        if not isinstance(workflow, Workflow):
+            # This may be better as a cast, since this seems an artificial case.
+            raise TypeError("Can only return a workflow of the same type")
         return workflow
 
-    def set_result(self, result: StepReference[Any]) -> None:
+    def set_result(self, result: Basic | list[Basic] | tuple[Basic]) -> None:
         """Choose the result step.
 
         Sets a step as being the result for the entire workflow.
@@ -616,29 +732,21 @@ class Workflow:
         Args:
             result: reference to the chosen step.
         """
-        if result.step.__workflow__ != self:
-            raise RuntimeError("Output must be from a step in this workflow.")
+        _, refs = expr_to_references(result)
+        for entry in refs:
+            if entry.__workflow__ != self:
+                raise RuntimeError("Output must be from a step in this workflow.")
         self.result = result
 
-
-class WorkflowComponent:
-    """Base class for anything directly tied to an individual `Workflow`.
-
-    Attributes:
-        __workflow__: the `Workflow` that this is tied to.
-    """
-
-    __workflow__: Workflow
-
-    def __init__(self, workflow: Workflow):
-        """Tie to a `Workflow`.
-
-        All subclasses must call this.
-
-        Args:
-            workflow: the `Workflow` to tie to.
-        """
-        self.__workflow__ = workflow
+    @property
+    def result_type(self) -> type:
+        """Overall return type of this workflow."""
+        if self.result is None:
+            return type(None)
+        if hasattr(self.result, "__type__"):
+            return self.result.__type__
+        # TODO: get individual types!
+        return type(self.result)
 
 
 class WorkflowLinkedComponent(Protocol):
@@ -657,14 +765,206 @@ class WorkflowLinkedComponent(Protocol):
         ...
 
 
-class Reference:
-    """Superclass for all symbolic references to values."""
+class FieldableProtocol(Protocol):
+    """Expected interfaces for a type that can take fields.
+
+    Attributes:
+        __field__: tuple representing the named fields, either strings or integers.
+    """
+    __field__: tuple[str | int, ...]
+
+    @property
+    def __field_sep__(self) -> str:
+        """The separator that should be used by default when rendering a name."""
+
+    @property
+    def __field_index_types__(self) -> tuple[type, ...]:
+        """Get the types that will be rendered as an index [x] rather than a field .x on stringifying.
+
+        Will be taken from the `field_index_types` construct configuration.
+        """
+
+    def __init__(self, *args: Any, field: str | None = None, **kwargs: Any):
+        """Extract the field name from the initializer arguments, if provided."""
+        super().__init__(*args, **kwargs)
+
+    @property
+    def __name__(self: FieldableProtocol) -> str:
+        """Name of the fieldable, which may not be `name` if this is needed as an internal reference."""
+        return self.name
+
+    @property
+    def __type__(self) -> type:
+        """Type of this field with the overall target."""
+        ...
 
     @property
     def name(self) -> str:
-        """Referral name for this reference."""
-        raise NotImplementedError("Reference must provide a name")
+        """The name for the target, accounting for the field."""
+        return "name"
 
+    def __make_reference__(self, *args: Any, **kwargs: Any) -> Reference[Any]:
+        """Create a reference with constructor arguments, usually to a subfield."""
+        ...
+
+# This required so that Mixins can trust that
+# superclasss attributes will be available for mypy,
+# but do not confuse the MRO.
+if TYPE_CHECKING:
+    _Fieldable = FieldableProtocol
+else:
+    _Fieldable = object
+
+# Subclass Reference so that we know Reference methods/attrs are available.
+class FieldableMixin(_Fieldable):
+    """Tooling for enhancing a type with referenceable fields."""
+
+    def __init__(self: FieldableProtocol, *args: Any, field: str | int | tuple[str | int, ...] | None = None, **kwargs: Any):
+        """Extract the requested field, if any, from the initializer arguments.
+
+        Args:
+            field: the new subfield, either an index (int) or a fieldname (str) or a field tuple representing the whole path, or None.
+            *args: arguments to pass to the other initializers.
+            **kwargs: arguments to pass to the other initializers.
+        """
+        self.__field__: tuple[str, ...] = (field if isinstance(field, tuple) else (field,)) if field is not None else ()
+        super().__init__(*args, **kwargs)
+
+    @property
+    def __field_sep__(self) -> str:
+        """Get the field separator.
+
+        Will be taken from the configuration key, `field_separator`.
+        """
+        sep = get_configuration("field_separator")
+        if not isinstance(sep, str):
+            raise TypeError(f"The `field_separator` configuration argument must be a string not {type(sep)}")
+        return sep
+
+    @property
+    def __field_index_types__(self) -> tuple[type, ...]:
+        """Get the types that will be rendered as an index [x] rather than a field .x on stringifying.
+
+        Will be taken from the `field_index_types` construct configuration.
+        """
+        types = get_configuration("field_index_types")
+        if not isinstance(types, str):
+            raise TypeError(f"The `field_index_types` configuration argument should be a comma-separated string of types from: {', '.join(AVAILABLE_TYPES.keys())}")
+        tup_all = tuple(AVAILABLE_TYPES.get(typ) for typ in types.split(",") if typ)
+        tup = tuple(t for t in tup_all if t is not None)
+        if tup_all != tup:
+            raise ValueError(
+                "Setting for fixed index types contains unavailable type: " +
+                f"{str(get_configuration('field_index_types'))} vs {tup}"
+            )
+        return tup
+
+    @property
+    def __field_str__(self) -> str:
+        """Stringified field, without the name."""
+        return self.__field_suffix__.lstrip(self.__field_sep__)
+
+    @property
+    def __field_suffix__(self) -> str:
+        """Stringified field, without the name but with an appropriate separator at the start."""
+        result = ""
+        for cmpt in self.__field__:
+            if any(isinstance(cmpt, typ) for typ in self.__field_index_types__):
+                result += f"[{cmpt}]"
+            else:
+                result += f"{self.__field_sep__}{cmpt}"
+        return result
+
+    def __field_up__(self) -> Reference[Any]:
+        """Get the parent field, if possible.
+
+        Returns: reference to the field above this.
+
+        Raises:
+            RuntimeError: if there is no field above this.
+        """
+        if self.__field__:
+            return self.__make_reference__(field=tuple(self.__field__[:-1]))
+        raise RuntimeError("Cannot go upwards unless currently using a field.")
+
+    @property
+    def __name__(self) -> str:
+        """Name for this step.
+
+        May be remapped by the workflow to something nicer
+        than the ID.
+        """
+        return super().__name__ + self.__field_suffix__
+
+    def find_field(self: FieldableProtocol, field: str | int, fallback_type: type | None = None, **init_kwargs: Any) -> Reference[Any]:
+        """Field within the reference, if possible.
+
+        Args:
+            field: the field to search for.
+            fallback_type: the type to use if we do not know a more specific one.
+            **init_kwargs: arguments to use for constructing a new reference (via `__make_reference__`).
+
+        Returns:
+            A field-specific version of this reference.
+        """
+        # Get new type, for the specific field.
+        parent_type, _ = strip_annotations(self.__type__)
+        field_type = fallback_type
+        base = get_origin(parent_type) or parent_type
+
+        if isinstance(field, int):
+            if not inspect.isclass(base) or not issubclass(base, Sequence):
+                raise AttributeError(f"Tried to index int {field} into a non-sequence type {parent_type} (base: {base})")
+            if not (field_type := get_args(parent_type)[0]):
+                raise AttributeError(
+                    f"Tried to index int {field} into type {parent_type} but can only do so if the first type argument "
+                    f"is the element type (args: {get_args(parent_type)}"
+                )
+        elif field.startswith("__"):
+            raise AttributeError(f"We do not allow fields with dunder prefix, such as {field}, to reduce risk of clashes.")
+        else:
+            if is_dataclass(parent_type):
+                try:
+                    type_hints = get_type_hints(parent_type, localns={parent_type.__name__: parent_type}, include_extras=True)
+                    field_type = type_hints.get(field)
+                    if field_type is None:
+                        field_type = next(iter(filter(lambda fld: fld.name == field, dataclass_fields(parent_type)))).type
+                except StopIteration:
+                    raise AttributeError(f"Dataclass {parent_type} does not have field {field}") from None
+            elif attr_has(parent_type):
+                resolve_types(parent_type)
+                try:
+                    field_type = getattr(attrs_fields(parent_type), field).type
+                except AttributeError as exc:
+                    raise AttributeError(f"attrs-class {parent_type} does not have field {field}") from exc
+            # TypedDict
+            elif inspect.isclass(parent_type) and issubclass(parent_type, dict) and hasattr(parent_type, "__annotations__"):
+                try:
+                    field_type = get_type_hints(parent_type, include_extras=True)[field]
+                except KeyError as exc:
+                    raise AttributeError(f"TypedDict {parent_type} does not have field {field}") from exc
+            if not field_type and get_configuration("allow_plain_dict_fields") and inspect.isclass(base) and issubclass(base, dict):
+                args = get_args(parent_type)
+                if len(args) == 2 and args[0] is str:
+                    field_type = args[1]
+                else:
+                    raise AttributeError("Can only get fields for plain dicts if annotated dict[str, TYPE]")
+
+        if field_type:
+            if not issubclass(self.__class__, Reference):
+                raise TypeError("Only references can have a fieldable mixin")
+
+            new_field: tuple[str | int, ...] | str | int
+            if self.__field__:
+                new_field = tuple(list(self.__field__) + [field])
+            else:
+                new_field = field
+
+            return self.__make_reference__(typ=field_type, field=new_field, **init_kwargs)
+
+        raise AttributeError(
+            f"Could not determine the type for field {field} in type {parent_type} (type of parent type is {type(parent_type)})"
+        )
 
 class BaseStep(WorkflowComponent):
     """Lazy-evaluated function call.
@@ -679,13 +979,15 @@ class BaseStep(WorkflowComponent):
 
     _id: str | None = None
     task: Task | Workflow
-    arguments: Mapping[str, Reference | Raw]
+    arguments: Mapping[str, Basic | Reference[Any] | Raw]
+    workflow: Workflow
+    positional_args: dict[str, bool] | None = None
 
     def __init__(
         self,
         workflow: Workflow,
         task: Task | Workflow,
-        arguments: Mapping[str, Reference | Raw],
+        arguments: Mapping[str, Reference[Any] | Raw],
         raw_as_parameter: bool = False,
     ):
         """Initialize a step.
@@ -696,7 +998,7 @@ class BaseStep(WorkflowComponent):
             arguments: key-value pairs to pass to the function.
             raw_as_parameter: whether to turn any raw-type arguments into workflow parameters (or just keep them as default argument values).
         """
-        super().__init__(workflow)
+        super().__init__(workflow=workflow)
         self.task = task
         self.arguments = {}
         for key, value in arguments.items():
@@ -705,6 +1007,9 @@ class BaseStep(WorkflowComponent):
                 or isinstance(value, Reference)
                 or isinstance(value, Raw)
                 or is_raw(value)
+                or is_expr(value)
+                or is_dataclass(value)
+                or attr_has(value)
             ):
                 # Avoid recursive type issues
                 if (
@@ -714,15 +1019,22 @@ class BaseStep(WorkflowComponent):
                     and is_raw(value)
                 ):
                     if raw_as_parameter:
-                        value = ParameterReference(
-                            workflow, param(key, value, tethered=None)
-                        )
+                        # We use param for convenience but note that it is a reference in disguise.
+                        value = cast(Parameter[Any], param(key, value, tethered=None)).make_reference(workflow=workflow)
                     else:
                         value = Raw(value)
-                if isinstance(value, ParameterReference):
-                    parameter = value.parameter
-                    parameter.register_caller(self)
-                self.arguments[key] = value
+
+                def _to_param_ref(value: Any) -> ParameterReference[Any] | None:
+                    if isinstance(value, Parameter):
+                        return value.make_reference(workflow=workflow)
+                    return None
+                expression, refs = expr_to_references(value, remap=_to_param_ref)
+
+                for ref in refs:
+                    if isinstance(ref, ParameterReference):
+                        parameter = ref._.parameter
+                        parameter.register_caller(self)
+                self.arguments[key] = expression
             else:
                 raise RuntimeError(
                     f"Non-references must be a serializable type: {key}>{value} {type(value)}"
@@ -737,13 +1049,36 @@ class BaseStep(WorkflowComponent):
         if not isinstance(other, BaseStep):
             return False
         return (
-            self.__workflow__ == other.__workflow__
+            self.__workflow__ is other.__workflow__
             and self.task == other.task
             and self.arguments == other.arguments
         )
 
+    def make_reference(self, **kwargs: Any) -> "StepReference[T]":
+        """Create a reference to this step.
+
+        Builds a reference to the (result of) this step, which will be iterable if appropriate.
+
+        Args:
+            **kwargs: arguments for reference constructor, which will be supplemented appropriately.
+
+        Returns: a reference to the result of this step.
+        """
+        kwargs["step"] = self
+        kwargs.setdefault("typ", self.return_type)
+        typ = kwargs["typ"]
+        base = strip_annotations(typ)[0]
+        base = get_origin(base) or base
+        if inspect.isclass(base) and issubclass(base, Iterable) and not issubclass(base, str | bytes):
+            return IterableStepReference(**kwargs)
+        return StepReference(**kwargs)
+
+    def __hash__(self) -> int:
+        """Searchable hash for this step."""
+        return hash(self.id)
+
     def set_workflow(self, workflow: Workflow, with_arguments: bool = True) -> None:
-        """Move the step reference to a different workflow.
+        """Move the step reference to another workflow.
 
         This method is primarily intended to be called by a step, allowing it to
         switch to a new workflow. It also updates the workflow reference for any
@@ -756,11 +1091,8 @@ class BaseStep(WorkflowComponent):
         self.__workflow__ = workflow
         if with_arguments:
             for argument in self.arguments.values():
-                if hasattr(argument, "__workflow__"):
-                    try:
-                        argument.__workflow__ = workflow
-                    except AttributeError:
-                        ...
+                unify_workflows(argument, workflow, set_only=True)
+        self._id = None
 
     @property
     def return_type(self) -> Any:
@@ -773,15 +1105,16 @@ class BaseStep(WorkflowComponent):
             Expected type of the return value.
         """
         if isinstance(self.task, Workflow):
-            if self.task.result:
-                return self.task.result.return_type
+            if self.task.result is not None:
+                return self.task.result_type
             else:
                 raise AttributeError(
                     "Cannot determine return type of a workflow with an unspecified result"
                 )
         if isinstance(self.task.target, type):
             return self.task.target
-        return inspect.signature(inspect.unwrap(self.task.target)).return_annotation
+        ann = get_type_hints(inspect.unwrap(self.task.target), include_extras=True)["return"]
+        return ann
 
     @property
     def name(self) -> str:
@@ -799,12 +1132,13 @@ class BaseStep(WorkflowComponent):
             self._id = self._generate_id()
             return self._id
 
-        check_id = self._generate_id()
-        if check_id != self._id:
-            return self._id
-            raise RuntimeError(
-                f"Cannot change a step after requesting its ID: {self.task}"
-            )
+        if CHECK_IDS:
+            check_id = self._generate_id()
+            if check_id != self._id:
+                return self._id
+                raise RuntimeError(
+                    f"Cannot change a step after requesting its ID: {self.task}"
+                )
         return self._id
 
     def _generate_id(self) -> str:
@@ -813,7 +1147,7 @@ class BaseStep(WorkflowComponent):
         for key, param in self.arguments.items():
             components.append((key, repr(param)))
 
-        comp_tup: tuple[str | tuple[str, str], ...] = tuple(components)
+        comp_tup: tuple[str | tuple[str, str], ...] = tuple(sorted(components, key=lambda pair: pair[0]))
 
         return f"{self.task}-{hasher(comp_tup)}"
 
@@ -829,7 +1163,7 @@ class NestedStep(BaseStep):
         workflow: Workflow,
         name: str,
         subworkflow: Workflow,
-        arguments: Mapping[str, Reference | Raw],
+        arguments: Mapping[str, Basic | Reference[Any] | Raw],
         raw_as_parameter: bool = False,
     ):
         """Create a NestedStep.
@@ -842,10 +1176,12 @@ class NestedStep(BaseStep):
             raw_as_parameter: whether raw-type arguments should be made (outer) workflow parameters.
         """
         self.__subworkflow__ = subworkflow
+        base_arguments: dict[str, Basic | Reference[Any] | Raw] = {p.name: p for p in subworkflow.find_parameters()}
+        base_arguments.update(arguments)
         super().__init__(
             workflow=workflow,
             task=subworkflow,
-            arguments=arguments,
+            arguments=base_arguments,
             raw_as_parameter=raw_as_parameter,
         )
 
@@ -864,9 +1200,10 @@ class NestedStep(BaseStep):
         Returns:
             Expected type of the return value.
         """
-        if not self.__subworkflow__.result:
+        result = self.__subworkflow__.result
+        if result is None or (isinstance(result, list | tuple) and not result):
             raise RuntimeError("Can only use a subworkflow if the reference exists.")
-        return self.__subworkflow__.result.return_type
+        return self.__subworkflow__.result_type
 
 
 class Step(BaseStep):
@@ -882,7 +1219,7 @@ class FactoryCall(Step):
         self,
         workflow: Workflow,
         task: Task | Workflow,
-        arguments: Mapping[str, Reference | Raw],
+        arguments: Mapping[str, Reference[Any] | Raw],
         raw_as_parameter: bool = False,
     ):
         """Initialize a step.
@@ -893,22 +1230,36 @@ class FactoryCall(Step):
             arguments: key-value pairs to pass to the function - for a factory call, these _must_ be raw.
             raw_as_parameter: whether to turn any raw-type arguments into workflow parameters (or just keep them as default argument values).
         """
-        for arg in list(arguments.values()):
-            if not is_raw(arg) and not (
+        for _, arg in arguments.items():
+            if not is_expr(arg) and not (
                 isinstance(arg, ParameterReference) and is_raw_type(arg.__type__)
             ):
+                try:
+                    arg_name = str(arg)
+                except:
+                    arg_name = "(unnamed)"
                 raise RuntimeError(
-                    f"Factories must be constructed with raw types {arg} {type(arg)}"
+                    f"Factories must be constructed with raw types in {arg_name} {type(arg)}"
                 )
-        super().__init__(workflow, task, arguments, raw_as_parameter=raw_as_parameter)
+        super().__init__(workflow=workflow, task=task, arguments=arguments, raw_as_parameter=raw_as_parameter)
 
     @property
-    def default(self) -> Unset:
+    def __name__(self) -> str:
+        """Get the name of this factory call."""
+        return self.name
+
+    @property
+    def __original_name__(self) -> str:
+        """Original name of a factory call is just its normal name."""
+        return self.name
+
+    @property
+    def __default__(self) -> Unset:
         """Dummy default property for use as property."""
         return UnsetType(self.return_type)
 
 
-class ParameterReference(Reference):
+class ParameterReference(FieldableMixin, Reference[U], WorkflowComponent):
     """Reference to an individual `Parameter`.
 
     Allows us to refer to the outputs of a `Parameter` in subsequent `Parameter`
@@ -916,39 +1267,122 @@ class ParameterReference(Reference):
 
     Attributes:
         parameter: `Parameter` referred to.
-        __workflow__: Related workflow. In this case, as Parameters are generic
+        workflow: Related workflow. In this case, as Parameters are generic
             but ParameterReferences are specific, this carries the actual workflow reference.
 
     Returns:
         Workflow that the referee is related to.
     """
 
-    parameter: Parameter[RawType]
-    __workflow__: Workflow
+    class ParameterReferenceMetadata(Generic[T]):
+        """Holder for attributes of this reference that we do not wish to risk confusing with fieldnames.
 
-    def __init__(self, __workflow__: Workflow, parameter: Parameter[RawType]):
-        """Initialize the reference.
+        Attributes:
+            parameter: the parameter to which this reference refers.
+        """
+        parameter: Parameter[T]
+
+        def __init__(self, parameter: Parameter[T], typ: type[U] | Unset=UNSET):
+            """Initialize the reference.
+
+            Args:
+                workflow: `Workflow` that this is tied to.
+                parameter: `Parameter` that this refers to.
+                typ: type that should override inferred type or None.
+                *args: any arguments for other initializers.
+                **kwargs: any arguments for other initializers.
+            """
+            self.parameter = parameter
+
+        @property
+        def unique_name(self) -> str:
+            """Unique, machine-generated name.
+
+            Normally this will become invisible in output, but it avoids circularity
+            as a step that uses this parameter will ask for this when constructing
+            its own hash, but we will normally want to use the step's name as part of
+            the parameter name to distinguish from other parameters of the same name.
+            """
+            return self.parameter.__name__
+
+    @property
+    def __default__(self) -> U | Unset:
+        """Default value of the parameter."""
+        default = self._.parameter.default
+        if isinstance(default, Unset):
+            return default
+
+        for field in self.__field__:
+            if isinstance(default, dict) or isinstance(field, int):
+                default = default[field]
+            else:
+                default = getattr(default, field)
+        return default
+
+    @property
+    def __root_name__(self) -> str:
+        """Reference based on the named step.
+
+        May be remapped by the workflow to something nicer
+        than the ID.
+        """
+        return self._.parameter.name
+
+    def __init__(self, parameter: Parameter[U], *args: Any, typ: type[U] | None=None, **kwargs: Any):
+        """Extract the parameter and type for setup.
 
         Args:
-            workflow: `Workflow` that this is tied to.
-            parameter: `Parameter` that this refers to.
+            parameter: the parameter to reference.
+            typ: an overriding type for this reference, or None.
+            *args: arguments for other initializers.
+            **kwargs: arguments for other initializers.
         """
-        self.parameter = parameter
-        self.__workflow__ = __workflow__
+        chosen_type = typ or parameter.__type__
+        self._ = self.ParameterReferenceMetadata(parameter, typ=chosen_type)
+        super().__init__(*args, typ=typ, **kwargs)
+
+    def __getitem__(self, attr: str) -> "ParameterReference[U]":
+        """Retrieve a field.
+
+        Args:
+            attr: attribute to get.
+
+        Returns: a reference to the field within this parameter, possibly nesting if we are already
+            referencing a field.
+        """
+        try:
+            return self.find_field(
+                field=attr,
+                workflow=self.__workflow__,
+                parameter=self._.parameter
+            )
+        except AttributeError as exc:
+            raise KeyError(
+                f"Key not found in {self.__root_name__} ({type(self)}:{self.__type__}): {attr}" +
+                (
+                    ". This could be because you are trying to iterate/index a reference whose type is not definitely iterable - double check your typehints."
+                    if isinstance(attr, int) else ""
+                )
+            ) from exc
 
     @property
-    def default(self) -> RawType | Unset:
-        """Default value of the parameter."""
-        return self.parameter.default
+    def __original_name__(self) -> str:
+        """The name of the original parameter, without any field, etc."""
+        return self._.parameter.__original_name__
 
-    @property
-    def __type__(self) -> type:
-        """Type represented by wrapped parameter."""
-        return self.parameter.__type__
+    def __getattr__(self, attr: str) -> "ParameterReference[U] | Any":
+        """Retrieve a field.
 
-    def __str__(self) -> str:
-        """Global description of the reference."""
-        return self.parameter.full_name
+        Args:
+            attr: attribute to get.
+
+        Returns: a reference to the field within this parameter, possibly nesting if we are already
+            referencing a field.
+        """
+        try:
+            return self[attr]
+        except KeyError as _:
+            return super().__getattribute__(attr)
 
     def __repr__(self) -> str:
         """Hashable reference to the step (and field)."""
@@ -956,27 +1390,8 @@ class ParameterReference(Reference):
             typ = self.__type__.__name__
         except AttributeError:
             typ = str(self.__type__)
-        return f"{typ}|:param:{self.unique_name}"
-
-    @property
-    def unique_name(self) -> str:
-        """Unique, machine-generated name.
-
-        Normally this will become invisible in output, but it avoids circularity
-        as a step that uses this parameter will ask for this when constructing
-        its own hash, but we will normally want to use the step's name as part of
-        the parameter name to distinguish from other parameters of the same name.
-        """
-        return self.parameter.__name__
-
-    @property
-    def name(self) -> str:
-        """Reference based on the named step.
-
-        May be remapped by the workflow to something nicer
-        than the ID.
-        """
-        return self.__workflow__.remap(self.parameter.name)
+        name = self._.unique_name + self.__field_suffix__
+        return f"{typ}|:param:{name}"
 
     def __hash__(self) -> int:
         """Hash to parameter.
@@ -984,7 +1399,7 @@ class ParameterReference(Reference):
         Returns:
             Unique hash corresponding to the parameter.
         """
-        return hash(self.parameter)
+        return hash((self._.parameter, self.__field__))
 
     def __eq__(self, other: object) -> bool:
         """Compare two references.
@@ -995,42 +1410,98 @@ class ParameterReference(Reference):
         Returns:
             True if the other parameter reference is materially the same, otherwise False.
         """
+        # We are equal to a parameter if we are a direct, fieldless, reference to it.
         return (
-            isinstance(other, ParameterReference) and self.parameter == other.parameter
+            (isinstance(other, ParameterReference) and self._.parameter == other._.parameter and self.__field__ == other.__field__)
         )
 
+    def __make_reference__(self, **kwargs: Any) -> "ParameterReference[U]":
+        """Get a reference for the same parameter."""
+        if "workflow" not in kwargs:
+            kwargs["workflow"] = self.__workflow__
+        return self._.parameter.make_reference(**kwargs)
 
-U = TypeVar("U")
+class IterableParameterReference(IterableMixin[U], ParameterReference[U]):
+    """Iterable form of parameter references."""
+    def __iter__(self) -> Generator[Reference[U], None, None]:
+        """Iterate over this parameter.
 
+        Returns:
+            Get values back for this parameter, normally references of the appropriate type.
+        """
+        inner, metadata = strip_annotations(self.__type__)
+        if metadata and "AtRender" in metadata and isinstance(self.__default__, Iterable):
+            yield from self.__default__
+        else:
+            yield from super().__iter__()
 
-class StepReference(Generic[U], Reference):
+    def __inner_iter__(self) -> Generator[Any, None, None]:
+        """Iterate over this parameter.
+
+        This is intended for overriding as a convenience way of iterating over a parameter,
+        and the yielded values will be ignored, in favour of new references.
+
+        Returns: a generator of any type.
+        """
+        inner, metadata = strip_annotations(self.__type__)
+        if self.__fixed_len__ is not None:
+            yield from range(self.__fixed_len__)
+        elif metadata and "Fixed" in metadata and isinstance(self.__default__, Sized):
+            yield from range(len(self.__default__))
+        else:
+            while True:
+                yield None
+
+    def __len__(self) -> int:
+        """If it is possible to get a hard-codeable length from this iterable parameter, do so."""
+        inner, metadata = strip_annotations(self.__type__)
+        if metadata and "Fixed" in metadata and isinstance(self.__default__, Sized):
+            return len(self.__default__)
+        return super().__len__()
+
+class StepReference(FieldableMixin, Reference[U]):
     """Reference to an individual `Step`.
 
     Allows us to refer to the outputs of a `Step` in subsequent `Step`
     arguments.
 
     Attributes:
-        step: `Step` referred to.
+        _: metadata wrapping the `Step` referred to.
     """
 
     step: BaseStep
-    _tethered_workflow: Workflow | None
-    _field: str | None
-    typ: type[U]
 
-    @property
-    def field(self) -> str:
-        """Field within the result.
+    class StepReferenceMetadata:
+        """Wrapper for any metadata that we would not want to conflict with fieldnames.
 
-        Explicitly set field (within an attrs-class) or `out`.
-
-        Returns:
-            Field name.
+        Attributes:
+            step: the step being wrapped.
+            _typ: the type to return, if overriding the step's own type, or None.
         """
-        return self._field or "out"
+
+        def __init__(
+            self, step: BaseStep, typ: type[U] | None = None
+        ):
+            """Initialize the reference.
+
+            Args:
+                workflow: `Workflow` that this is tied to.
+                step: `Step` that this refers to.
+                typ: the type that the step will output.
+                field: if provided, a specific field to pull out of an attrs result class.
+            """
+            self.step = step
+            self._typ = typ
+
+        @property
+        def return_type(self) -> type:
+            """Type of this reference, which may be overridden or may be the step's own type."""
+            return self._typ or self.step.return_type
+
+    _: StepReferenceMetadata
 
     def __init__(
-        self, workflow: Workflow, step: BaseStep, typ: type[U], field: str | None = None
+        self, step: BaseStep, *args: Any, typ: type[U] | None = None, **kwargs: Any
     ):
         """Initialize the reference.
 
@@ -1039,21 +1510,26 @@ class StepReference(Generic[U], Reference):
             step: `Step` that this refers to.
             typ: the type that the step will output.
             field: if provided, a specific field to pull out of an attrs result class.
+            *args: arguments for other initializers.
+            **kwargs: arguments for other initializers.
         """
-        self.step = step
-        self._field = field
-        self.typ = typ
-        self._tethered_workflow = None
+        typ = typ or step.return_type
+        self._ = self.StepReferenceMetadata(step, typ=typ)
+        super().__init__(*args, typ=typ, **kwargs)
 
     def __str__(self) -> str:
         """Global description of the reference."""
-        return f"{self.step.id}/{self.field}"
+        return self.__name__
 
     def __repr__(self) -> str:
         """Hashable reference to the step (and field)."""
-        return f"{self.step.id}/{self.field}"
+        return self._.step.id + self.__field_suffix__
 
-    def __getattr__(self, attr: str) -> "StepReference[Any]":
+    def __hash__(self) -> int:
+        """Hashable value for this workflow."""
+        return hash((repr(self), id(self.__workflow__)))
+
+    def __getitem__(self, attr: str) -> "StepReference[Any]":
         """Reference to a field within this result, if possible.
 
         If the result is an attrs-class or dataclass, this will pull out an individual
@@ -1069,101 +1545,79 @@ class StepReference(Generic[U], Reference):
             AttributeError: if this field is not present in the dataclass.
             RuntimeError: if this field is not available, or we do not have a structured result.
         """
-        if self._field is None:
-            typ: type | None
-            if attr_has(self.typ):
-                resolve_types(self.typ)
-                typ = getattr(attrs_fields(self.typ), attr).type
-            elif is_dataclass(self.typ):
-                matched = [
-                    field for field in dataclass_fields(self.typ) if field.name == attr
-                ]
-                if not matched:
-                    raise AttributeError(f"Field {attr} not present in dataclass")
-                typ = matched[0].type
-            elif isinstance(self.step, FactoryCall):
-                typ = self.step.return_type
-            else:
-                typ = None
-
-            if typ:
-                return self.__class__(
-                    workflow=self.__workflow__, step=self.step, typ=typ, field=attr
+        try:
+            return self.find_field(
+                workflow=self.__workflow__, step=self._.step, field=attr
+            )
+        except AttributeError as exc:
+            raise KeyError(
+                f"Key not found in {self.__root_name__} ({type(self)}:{self.__type__}): {attr}" +
+                (
+                    ". This could be because you are trying to iterate/index a reference whose type is not definitely iterable - double check your typehints."
+                    if isinstance(attr, int) else ""
                 )
-        raise AttributeError(
-            "Can only get attribute of a StepReference representing an attrs-class or dataclass"
-        )
+            ) from exc
+
+    def __getattr__(self, attr: str) -> "StepReference[U] | Any":
+        """Retrieve a field within this workflow."""
+        try:
+            return self[attr]
+        except KeyError as exc:
+            try:
+                return super().__getattribute__(attr)
+            except AttributeError as inner_exc:
+                raise inner_exc from exc
 
     @property
-    def return_type(self) -> type[U]:
-        """Type that this step reference will resolve to.
-
-        Returns:
-            Python type indicating the final result type.
-        """
-        return self.typ
+    def __type__(self) -> type:
+        """Get the type to which this step reference refers."""
+        return self._.return_type
 
     @property
-    def name(self) -> str:
+    def __root_name__(self) -> str:
         """Reference based on the named step.
 
         May be remapped by the workflow to something nicer
         than the ID.
         """
-        return f"{self.step.name}/{self.field}"
+        return self._.step.name
 
     @property
-    def __type__(self) -> Any:
-        """Type of the step's referenced value."""
-        return self.step.return_type
-
-    @property
-    def __workflow__(self) -> Workflow:
+    def __workflow__(self) -> WorkflowProtocol:
         """Related workflow.
 
         Returns:
             Workflow that the referee is related to.
         """
-        return self._tethered_workflow or self.step.__workflow__
+        return self._.step.__workflow__
 
     @__workflow__.setter
     def __workflow__(self, workflow: Workflow) -> None:
         """Sets related workflow.
 
-        We update the tethered workflow. If the step is missing from
-        this workflow then, by construction, it should have at least
-        been through an indexing process once, so we should be able
-        to get it back by name.
-
         Args:
             workflow: workflow to update the step
         """
-        self._tethered_workflow = workflow
-        if self._tethered_workflow:
-            if self.step not in self._tethered_workflow.steps:
-                self.step = self._tethered_workflow._indexed_steps[self.step.id]
+        self._.step.set_workflow(workflow)
 
-    @__workflow__.setter
-    def __workflow__(self, workflow: Workflow) -> None:
-        self.step.set_workflow(workflow)
+    def __make_reference__(self, **kwargs: Any) -> "StepReference[U]":
+        """Create a new reference for the same step."""
+        if "workflow" not in kwargs:
+            kwargs["workflow"] = self.__workflow__
+        return self._.step.make_reference(**kwargs)
 
+class IterableStepReference(IterableMixin[U], StepReference[U]):
+    """Iterable form of a step reference."""
+    def __iter__(self) -> Generator[Reference[U], None, None]:
+        """Gets a sentinel value for iterating over this step's results.
 
-def merge_workflows(*workflows: Workflow) -> Workflow:
-    """Combine several workflows into one.
-
-    Merges a series of workflows by combining steps and tasks.
-
-    Argument:
-        *workflows: series of workflows to combine.
-
-    Returns:
-        One workflow with all steps.
-    """
-    base = list(workflows).pop()
-    for workflow in workflows:
-        base = Workflow.assimilate(base, workflow)
-    return base
-
+        Bear in mind that this means an iterable step reference will iterate exactly once,
+        and return this Generator. The IteratedGenerator can be used as an iterator itself,
+        and will yield an infinite sequence of numbered field references, which renderers can use
+        for zipping with a fixed length iterator, or simply prepping fieldnames for serialization.
+        """
+        # We cast this so that we can treat a step iterator as if it really loops over results.
+        yield cast(Reference[U], IteratedGenerator(self))
 
 def is_task(task: Lazy) -> bool:
     """Decide whether this is a task.
@@ -1179,3 +1633,104 @@ def is_task(task: Lazy) -> bool:
         True if `task` is indeed a task.
     """
     return isinstance(task, LazyEvaluation)
+
+def expr_to_references(expression: Any, remap: Callable[[Any], Any] | None = None) -> tuple[ExprType, list[Reference[Any] | Parameter[Any]]]:
+    """Pull out any references, or other free symbols, from an expression.
+
+    Args:
+        expression: normally a reference that can be immediately returned, but may be a sympy expression or a dict/tuple/list/etc. of such.
+        remap: a callable to project certain values down before extracting symbols, or None.
+
+    Returns: a pair of the expression with any applied simplifications/standardizations, and the list of References/Parameters found.
+    """
+    to_check: list[Reference[Any] | Parameter[Any]] = []
+    def _to_expr(value: Any) -> ExprType:
+        if remap and (res := remap(value)) is not None:
+            return _to_expr(res)
+
+        if isinstance(value, Reference):
+            to_check.append(value)
+            return value
+
+        if value is None:
+            return None
+
+        if isinstance(value, Symbol):
+            return value
+        elif isinstance(value, Basic):
+            for sym in value.free_symbols:
+                new_sym = _to_expr(sym)
+                if new_sym != sym:
+                    value = value.subs(sym, new_sym)
+            return value
+
+        if is_dataclass(value) or attr_has(value):
+            if is_dataclass(value):
+                fields = list(dataclass_fields(value))
+            else:
+                fields = list({field for field in attrs_fields(value)})
+            for field in fields:
+                if hasattr(value, field.name) and isinstance((val := getattr(value, field.name)), Reference):
+                    setattr(value, field.name, _to_expr(val))
+            return value
+
+        # We need to look inside a Raw, but we do not want to lose it if
+        # we do not need to.
+        retval = value
+        if isinstance(value, Raw):
+            value = value.value
+
+        if isinstance(value, Mapping):
+            dct = {key: _to_expr(val) for key, val in value.items()}
+            if dct == value:
+                return retval
+            # We try to reinstantiate this, but there will be an error otherwise.
+            # TODO: we could check this with a protocol, but some care would be needed to ensure all valid
+            # cases are covered.
+            return value.__class__(dct) # type: ignore
+        elif not isinstance(value, str | bytes) and isinstance(value, Iterable):
+            lst = (tuple if isinstance(value, tuple) else list)(_to_expr(v) for v in value)
+            if lst == value:
+                return retval
+            return lst
+        return retval
+
+    expression = _to_expr(expression)
+
+    #if {sym for sym in symbols if not is_raw(sym)} != set(to_check):
+    #    print(symbols, to_check, [type(r) for r in symbols])
+    #    raise RuntimeError("The only symbols allowed are references (to e.g. step or parameter)")
+    return expression, to_check
+
+def unify_workflows(expression: Any, base_workflow: Workflow | None, set_only: bool = False) -> tuple[Basic | None, Workflow | None]:
+    """Takes an expression and ensures all of its references exist in the same workflow.
+
+    Args:
+        expression: any valid argument to `dewret.workflow.expr_to_references`.
+        base_workflow: the desired workflow to align on, or None.
+        set_only: whether to bother assimilating all the workflows (False), or to assume that has been done (False).
+
+    Returns: a pair of the (standardized) expression and the workflow that now contains it.
+    """
+    expression, to_check = expr_to_references(expression)
+    if not to_check:
+        return expression, base_workflow
+
+    # Build a unified workflow
+    collected_workflow = base_workflow or next(iter(to_check)).__workflow__
+    # This is a bit of an artifical check. We could rule out non-Workflow WorkflowProtocol implementers and simplify this.
+    if not isinstance(collected_workflow, Workflow):
+        raise NotImplementedError("Can only unify workflows on the same type: Workflow")
+    if not set_only:
+        for step_result in to_check:
+            new_workflow = step_result.__workflow__
+            if not isinstance(new_workflow, Workflow):
+                raise NotImplementedError("Can only unify workflows on the same type: Workflow")
+            if collected_workflow != new_workflow and collected_workflow and new_workflow:
+                collected_workflow = Workflow.assimilate(collected_workflow, new_workflow)
+
+    # Make sure all the results share it
+    for step_result in to_check:
+        step_result.__workflow__ = collected_workflow
+
+    return expression, collected_workflow

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -13,6 +13,7 @@ def try_nothing() -> int:
         return increment(num=1)
     return increment(num=0)
 
+
 @task()
 def increase(num: int | float) -> float:
     """Add 1 to a number."""
@@ -62,9 +63,11 @@ def tuple_float_return() -> tuple[float, float]:
     """Return a tuple of floats."""
     return 48.856667, 2.351667
 
+
 @task()
 def reverse_list(to_sort: list[int | float]) -> list[int | float]:
     return to_sort[::-1]
+
 
 @task()
 def max_list(lst: list[int | float]) -> int | float:

--- a/tests/_lib/extra.py
+++ b/tests/_lib/extra.py
@@ -1,7 +1,17 @@
-from dewret.tasks import task, subworkflow
+from dewret.tasks import task, workflow
+
+from .other import nothing
 
 JUMP: float = 1.0
+test: float = nothing
 
+
+@workflow()
+def try_nothing() -> int:
+    """Check that we can see AtRender in another module."""
+    if nothing:
+        return increment(num=1)
+    return increment(num=0)
 
 @task()
 def increase(num: int | float) -> float:
@@ -33,7 +43,15 @@ def sum(left: int | float, right: int | float) -> int | float:
     return left + right
 
 
-@subworkflow()
+@task()
+def pi() -> float:
+    """Returns pi."""
+    import math
+
+    return math.pi
+
+
+@workflow()
 def triple_and_one(num: int | float) -> int | float:
     """Triple a number by doubling and adding again, then add 1."""
     return sum(left=sum(left=double(num=num), right=num), right=1)
@@ -43,3 +61,11 @@ def triple_and_one(num: int | float) -> int | float:
 def tuple_float_return() -> tuple[float, float]:
     """Return a tuple of floats."""
     return 48.856667, 2.351667
+
+@task()
+def reverse_list(to_sort: list[int | float]) -> list[int | float]:
+    return to_sort[::-1]
+
+@task()
+def max_list(lst: list[int | float]) -> int | float:
+    return max(lst)

--- a/tests/_lib/frender.py
+++ b/tests/_lib/frender.py
@@ -13,13 +13,14 @@ from dewret.render import base_render
 
 from .extra import JUMP
 
+
 class FrenderRendererConfiguration(TypedDict):
     allow_complex_types: bool
 
+
 def default_config() -> FrenderRendererConfiguration:
-    return FrenderRendererConfiguration({
-        "allow_complex_types": True
-    })
+    return FrenderRendererConfiguration({"allow_complex_types": True})
+
 
 @dataclass
 class NestedStepDefinition:
@@ -28,17 +29,14 @@ class NestedStepDefinition:
 
     @classmethod
     def from_nested_step(cls, nested_step: NestedStep) -> "NestedStepDefinition":
-        return cls(
-            name=nested_step.name,
-            subworkflow_name=nested_step.subworkflow.name
-        )
+        return cls(name=nested_step.name, subworkflow_name=nested_step.subworkflow.name)
 
     def render(self) -> str:
-        return \
-f"""
+        return f"""
 A portal called {self.name} to another workflow,
 whose name is {self.subworkflow_name}
 """
+
 
 @dataclass
 class StepDefinition:
@@ -46,13 +44,10 @@ class StepDefinition:
 
     @classmethod
     def from_step(cls, step: Step) -> "StepDefinition":
-        return cls(
-            name=step.name
-        )
+        return cls(name=step.name)
 
     def render(self) -> str:
-        return \
-f"""
+        return f"""
 Something called {self.name}
 """
 
@@ -80,15 +75,15 @@ class WorkflowDefinition:
         return cls(name=name, steps=steps)
 
     def render(self) -> str:
-        steps = "\n".join('* ' + indent(step.render(), '  ')[3:] for step in self.steps)
-        return \
-f"""
+        steps = "\n".join("* " + indent(step.render(), "  ")[3:] for step in self.steps)
+        return f"""
 I found a workflow called {self.name}.
 It has {len(self.steps)} steps!
 They are:
 {steps}
 It probably got made with JUMP={JUMP}
 """
+
 
 def render_raw(
     workflow: Workflow, **kwargs: Unpack[FrenderRendererConfiguration]
@@ -104,8 +99,7 @@ def render_raw(
         serialization.
     """
     # TODO: work out how to handle these hints correctly.
-    set_render_configuration(kwargs) # type: ignore
+    set_render_configuration(kwargs)  # type: ignore
     return base_render(
-        workflow,
-        lambda workflow: WorkflowDefinition.from_workflow(workflow).render()
+        workflow, lambda workflow: WorkflowDefinition.from_workflow(workflow).render()
     )

--- a/tests/_lib/frender.py
+++ b/tests/_lib/frender.py
@@ -1,0 +1,111 @@
+"""Testing example renderer.
+
+'Friendly render', outputting human-readable descriptions.
+"""
+
+from textwrap import indent
+from typing import Unpack, TypedDict
+from dataclasses import dataclass
+
+from dewret.core import set_render_configuration
+from dewret.workflow import Workflow, Step, NestedStep
+from dewret.render import base_render
+
+from .extra import JUMP
+
+class FrenderRendererConfiguration(TypedDict):
+    allow_complex_types: bool
+
+def default_config() -> FrenderRendererConfiguration:
+    return FrenderRendererConfiguration({
+        "allow_complex_types": True
+    })
+
+@dataclass
+class NestedStepDefinition:
+    name: str
+    subworkflow_name: str
+
+    @classmethod
+    def from_nested_step(cls, nested_step: NestedStep) -> "NestedStepDefinition":
+        return cls(
+            name=nested_step.name,
+            subworkflow_name=nested_step.subworkflow.name
+        )
+
+    def render(self) -> str:
+        return \
+f"""
+A portal called {self.name} to another workflow,
+whose name is {self.subworkflow_name}
+"""
+
+@dataclass
+class StepDefinition:
+    name: str
+
+    @classmethod
+    def from_step(cls, step: Step) -> "StepDefinition":
+        return cls(
+            name=step.name
+        )
+
+    def render(self) -> str:
+        return \
+f"""
+Something called {self.name}
+"""
+
+
+@dataclass
+class WorkflowDefinition:
+    name: str
+    steps: list[StepDefinition | NestedStepDefinition]
+
+    @classmethod
+    def from_workflow(cls, workflow: Workflow) -> "WorkflowDefinition":
+        steps: list[StepDefinition | NestedStepDefinition] = []
+        for step in workflow.indexed_steps.values():
+            if isinstance(step, Step):
+                steps.append(StepDefinition.from_step(step))
+            elif isinstance(step, NestedStep):
+                steps.append(NestedStepDefinition.from_nested_step(step))
+            else:
+                raise RuntimeError(f"Unrecognised step type: {type(step)}")
+
+        try:
+            name = workflow.name
+        except NameError:
+            name = "Work Doe"
+        return cls(name=name, steps=steps)
+
+    def render(self) -> str:
+        steps = "\n".join('* ' + indent(step.render(), '  ')[3:] for step in self.steps)
+        return \
+f"""
+I found a workflow called {self.name}.
+It has {len(self.steps)} steps!
+They are:
+{steps}
+It probably got made with JUMP={JUMP}
+"""
+
+def render_raw(
+    workflow: Workflow, **kwargs: Unpack[FrenderRendererConfiguration]
+) -> dict[str, str]:
+    """Render to a dict-like structure.
+
+    Args:
+        workflow: workflow to evaluate result.
+        **kwargs: additional configuration arguments - these should match CWLRendererConfiguration.
+
+    Returns:
+        Reduced form as a native Python dict structure for
+        serialization.
+    """
+    # TODO: work out how to handle these hints correctly.
+    set_render_configuration(kwargs) # type: ignore
+    return base_render(
+        workflow,
+        lambda workflow: WorkflowDefinition.from_workflow(workflow).render()
+    )

--- a/tests/_lib/nonfrender.py
+++ b/tests/_lib/nonfrender.py
@@ -8,13 +8,16 @@ from dewret.workflow import Workflow
 
 from .extra import JUMP
 
+
 class NonfrenderRendererConfiguration(TypedDict):
     allow_complex_types: bool
+
 
 # This should fail to load as default_config is not present. However it would
 # ignore the fact that the return type is not a (subtype of) dict[str, RawType]
 # def default_config() -> int:
 #     return 3
+
 
 def render_raw(
     workflow: Workflow, **kwargs: Unpack[NonfrenderRendererConfiguration]

--- a/tests/_lib/nonfrender.py
+++ b/tests/_lib/nonfrender.py
@@ -1,0 +1,22 @@
+"""Testing example renderer.
+
+Correctly fails to import to show a broken module being handled.
+"""
+
+from typing import Unpack, TypedDict
+from dewret.workflow import Workflow
+
+from .extra import JUMP
+
+class NonfrenderRendererConfiguration(TypedDict):
+    allow_complex_types: bool
+
+# This should fail to load as default_config is not present. However it would
+# ignore the fact that the return type is not a (subtype of) dict[str, RawType]
+# def default_config() -> int:
+#     return 3
+
+def render_raw(
+    workflow: Workflow, **kwargs: Unpack[NonfrenderRendererConfiguration]
+) -> dict[str, str]:
+    return {"JUMP": str(JUMP)}

--- a/tests/_lib/other.py
+++ b/tests/_lib/other.py
@@ -1,0 +1,3 @@
+from dewret.annotations import AtRender
+
+nothing: AtRender[bool] = True

--- a/tests/_lib/unfrender.py
+++ b/tests/_lib/unfrender.py
@@ -10,15 +10,16 @@ from dewret.workflow import Workflow
 # uses one is what breaks the module. It cannot be both
 # a package and not-a-package. This is importable by
 # adding a . before extra.
-from extra import JUMP # type: ignore
+from extra import JUMP  # type: ignore
+
 
 class UnfrenderRendererConfiguration(TypedDict):
     allow_complex_types: bool
 
+
 def default_config() -> UnfrenderRendererConfiguration:
-    return {
-        "allow_complex_types": True
-    }
+    return {"allow_complex_types": True}
+
 
 def render_raw(
     workflow: Workflow, **kwargs: Unpack[UnfrenderRendererConfiguration]

--- a/tests/_lib/unfrender.py
+++ b/tests/_lib/unfrender.py
@@ -1,0 +1,26 @@
+"""Testing example renderer.
+
+Correctly fails to import to show a broken module being handled.
+"""
+
+from typing import Unpack, TypedDict
+from dewret.workflow import Workflow
+
+# This lacking a relative import, while extra itself
+# uses one is what breaks the module. It cannot be both
+# a package and not-a-package. This is importable by
+# adding a . before extra.
+from extra import JUMP # type: ignore
+
+class UnfrenderRendererConfiguration(TypedDict):
+    allow_complex_types: bool
+
+def default_config() -> UnfrenderRendererConfiguration:
+    return {
+        "allow_complex_types": True
+    }
+
+def render_raw(
+    workflow: Workflow, **kwargs: Unpack[UnfrenderRendererConfiguration]
+) -> dict[str, str]:
+    return {"JUMP": str(JUMP)}

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,200 @@
+"""Verify we can interrogate annotations."""
+
+import pytest
+import yaml
+
+from dewret.tasks import construct, workflow, TaskException
+from dewret.renderers.cwl import render
+from dewret.annotations import AtRender, FunctionAnalyser, Fixed
+from dewret.core import set_configuration
+
+from ._lib.extra import increment, sum, try_nothing
+
+ARG1: AtRender[bool] = True
+ARG2: bool = False
+
+
+class MyClass:
+    """A mock class to wrap values and mock processing of data."""
+
+    def method(self, arg1: bool, arg2: AtRender[int]) -> float:
+        """A mock method to simulate the behavior of processing and rendering values."""
+        arg3: float = 7.0
+        arg4: AtRender[float] = 8.0
+        return arg1 + arg2 + arg3 + arg4 + int(ARG1) + int(ARG2)
+
+
+def fn(arg5: int, arg6: AtRender[int]) -> float:
+    """A mock function to simulate processing of rendered values with integer inputs."""
+    arg7: float = 7.0
+    arg8: AtRender[float] = 8.0
+    return arg5 + arg6 + arg7 + arg8 + int(ARG1) + int(ARG2)
+
+
+@workflow()
+def to_int_bad(num: int, should_double: bool) -> int | float:
+    """A mock workflow that casts to an int with a wrong type for handling doubles."""
+    return increment(num=num) if should_double else sum(left=num, right=num)
+
+
+@workflow()
+def to_int(num: int, should_double: AtRender[bool]) -> int | float:
+    """A mock workflow that casts to an int with a right type for handling doubles."""
+    return increment(num=num) if should_double else sum(left=num, right=num)
+
+
+def test_can_analyze_annotations() -> None:
+    """Test that annotations can be correctly analyzed within methods and functions.
+
+    Verifies that the `FunctionAnalyser` finds which arguments
+    and global variables are derived from `dewret.annotations.AtRender`.
+    """
+    my_obj = MyClass()
+
+    analyser = FunctionAnalyser(my_obj.method)
+    assert analyser.argument_has("arg1", AtRender, exhaustive=True) is False
+    assert analyser.argument_has("arg3", AtRender, exhaustive=True) is False
+    assert analyser.argument_has("ARG2", AtRender, exhaustive=True) is False
+    assert analyser.argument_has("arg2", AtRender, exhaustive=True) is True
+    assert (
+        analyser.argument_has("arg4", AtRender, exhaustive=True) is False
+    )  # Not a global/argument
+    assert analyser.argument_has("ARG1", AtRender, exhaustive=True) is True
+    assert analyser.argument_has("ARG1", AtRender) is False
+
+    analyser = FunctionAnalyser(fn)
+    assert analyser.argument_has("arg5", AtRender, exhaustive=True) is False
+    assert analyser.argument_has("arg7", AtRender, exhaustive=True) is False
+    assert analyser.argument_has("ARG2", AtRender, exhaustive=True) is False
+    assert analyser.argument_has("arg6", AtRender, exhaustive=True) is True
+    assert (
+        analyser.argument_has("arg8", AtRender, exhaustive=True) is False
+    )  # Not a global/argument
+    assert analyser.argument_has("ARG1", AtRender, exhaustive=True) is True
+    assert analyser.argument_has("ARG1", AtRender) is False
+
+
+def test_at_render() -> None:
+    """Test the rendering of workflows with `dewret.annotations.AtRender` and exceptions handling."""
+    with pytest.raises(TaskException) as _:
+        result = to_int_bad(num=increment(num=3), should_double=True)
+        wkflw = construct(result, simplify_ids=True)
+
+    result = to_int(num=increment(num=3), should_double=True)
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
+    assert rendered == yaml.safe_load("""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          increment-1-num:
+            default: 3
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: to_int-1/out
+            type:
+            - int
+            - float
+        steps:
+          increment-1:
+            in:
+              num:
+                source: increment-1-num
+            out:
+            - out
+            run: increment
+          to_int-1:
+            in:
+              num:
+                source: increment-1/out
+              should_double:
+                default: True
+            out:
+            - out
+            run: to_int
+    """)
+
+    result = to_int(num=increment(num=3), should_double=False)
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
+    assert rendered == yaml.safe_load("""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          increment-1-num:
+            default: 3
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: to_int-1/out
+            type:
+            - int
+            - float
+        steps:
+          increment-1:
+            in:
+              num:
+                source: increment-1-num
+            out:
+            - out
+            run: increment
+          to_int-1:
+            in:
+              num:
+                source: increment-1/out
+              should_double:
+                default: False
+            out:
+            - out
+            run: to_int
+    """)
+
+
+def test_at_render_between_modules() -> None:
+    """Test rendering of workflows across different modules using `dewret.annotations.AtRender`."""
+    result = try_nothing()
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    subworkflows["__root__"]
+
+
+list_2: Fixed[list[int]] = [0, 1, 2, 3]
+
+
+def test_can_loop_over_fixed_length() -> None:
+    """Test looping over a fixed-length list using `dewret.annotations.Fixed`."""
+
+    @workflow()
+    def loop_over_lists(list_1: list[int]) -> list[int]:
+        result = []
+        for a, b in zip(list_1, list_2, strict=False):
+            result.append(a + b + len(list_2))
+        return result
+
+    with set_configuration(flatten_all_nested=True):
+        result = loop_over_lists(list_1=[5, 6, 7, 8])
+        wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs: {}
+        outputs:
+          out:
+            type: float
+            label: out
+            expression: '[4 + list_1[0] + list_2[0], 4 + list_1[1] + list_2[1], 4 + list_1[2] + list_2[2],
+              4 + list_1[3] + list_2[3]]'
+            source:
+            - list_1
+            - list_2
+        steps: {}
+    """)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,71 @@
+"""Check configuration is consistent and usable."""
+
+import yaml
+import pytest
+from dewret.tasks import construct, workflow, TaskException
+from dewret.renderers.cwl import render
+from dewret.core import set_configuration
+from dewret.annotations import AtRender
+from ._lib.extra import increment
+
+
+@workflow()
+def floor(num: int, expected: AtRender[bool]) -> int:
+    """Converts int/float to int."""
+    from dewret.core import get_configuration
+
+    if get_configuration("flatten_all_nested") != expected:
+        raise AssertionError(
+            f"Not expected configuration: {str(get_configuration('flatten_all_nested'))} != {expected}"
+        )
+    return increment(num=num)
+
+
+def test_cwl_with_parameter() -> None:
+    """Test workflows with configuration parameters."""
+    with set_configuration(flatten_all_nested=True):
+        result = increment(num=floor(num=3, expected=True))
+        workflow = construct(result, simplify_ids=True)
+
+    with (
+        pytest.raises(TaskException) as exc,
+        set_configuration(flatten_all_nested=False),
+    ):
+        result = increment(num=floor(num=3, expected=True))
+        workflow = construct(result, simplify_ids=True)
+    assert "AssertionError" in str(exc.getrepr())
+
+    with set_configuration(flatten_all_nested=True):
+        result = increment(num=floor(num=3, expected=True))
+        workflow = construct(result, simplify_ids=True)
+    rendered = render(workflow)["__root__"]
+    num_param = list(workflow.find_parameters())[0]
+    assert num_param
+
+    assert rendered == yaml.safe_load("""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          num:
+            label: num
+            type: int
+            default: 3
+        outputs:
+          out:
+            label: out
+            outputSource: increment-1/out
+            type: int
+        steps:
+          increment-2:
+            run: increment
+            in:
+                num:
+                    source: num
+            out: [out]
+          increment-1:
+            run: increment
+            in:
+                num:
+                    source: increment-2/out
+            out: [out]
+    """)

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -19,6 +19,7 @@ from ._lib.extra import (
     tuple_float_return,
 )
 
+
 @task()
 def floor(num: int | float) -> int:
     """Converts int/float to int."""
@@ -77,7 +78,9 @@ def test_input_factories() -> None:
     now = factory(get_now)()
     result = days_in_future(now=now, num=3)
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow, allow_complex_types=True, factories_as_params=True)["__root__"]
+    rendered = render(workflow, allow_complex_types=True, factories_as_params=True)[
+        "__root__"
+    ]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -170,6 +173,7 @@ def test_cwl_with_parameter() -> None:
                     source: increment-{hsh}-num
             out: [out]
     """)
+
 
 def test_cwl_with_positional_parameter() -> None:
     """Check whether we can move raw input to parameters.

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -1,13 +1,16 @@
 """Verify CWL output is OK."""
 
 import yaml
+import pytest
 from datetime import datetime, timedelta
-from dewret.tasks import construct, task, factory
+from dewret.core import set_configuration
+from dewret.tasks import construct, task, factory, TaskException
 from dewret.renderers.cwl import render
 from dewret.utils import hasher
 from dewret.workflow import param
 
 from ._lib.extra import (
+    pi,
     increment,
     double,
     mod10,
@@ -15,15 +18,6 @@ from ._lib.extra import (
     triple_and_one,
     tuple_float_return,
 )
-
-
-@task()
-def pi() -> float:
-    """Returns pi."""
-    import math
-
-    return math.pi
-
 
 @task()
 def floor(num: int | float) -> int:
@@ -50,7 +44,7 @@ def test_basic_cwl() -> None:
     """
     result = pi()
     workflow = construct(result)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
     hsh = hasher(("pi",))
 
     assert rendered == yaml.safe_load(f"""
@@ -83,7 +77,7 @@ def test_input_factories() -> None:
     now = factory(get_now)()
     result = days_in_future(now=now, num=3)
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow, allow_complex_types=True, factories_as_params=True)
+    rendered = render(workflow, allow_complex_types=True, factories_as_params=True)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -92,7 +86,7 @@ def test_input_factories() -> None:
           days_in_future-1-num:
             default: 3
             type: int
-            label: days_in_future-1-num
+            label: num
           get_now-1:
             label: get_now-1
             type: datetime
@@ -112,7 +106,7 @@ def test_input_factories() -> None:
             out: [out]
     """)
 
-    rendered = render(workflow, allow_complex_types=True)
+    rendered = render(workflow, allow_complex_types=True)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -121,7 +115,7 @@ def test_input_factories() -> None:
           days_in_future-1-num:
             default: 3
             type: int
-            label: days_in_future-1-num
+            label: num
         outputs:
           out:
             label: out
@@ -147,20 +141,57 @@ def test_cwl_with_parameter() -> None:
     """Check whether we can move raw input to parameters.
 
     Produces CWL for a call with a changeable raw value, that is converted
-    to a parameter, if and only if we are calling from outside a nested task.
+    to a parameter, if and only if we are calling from outside a subworkflow.
     """
     result = increment(num=3)
     workflow = construct(result)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
     num_param = list(workflow.find_parameters())[0]
-    hsh = hasher(("increment", ("num", f"int|:param:{num_param.unique_name}")))
+    hsh = hasher(("increment", ("num", f"int|:param:{num_param._.unique_name}")))
 
     assert rendered == yaml.safe_load(f"""
         cwlVersion: 1.2
         class: Workflow
         inputs:
           increment-{hsh}-num:
-            label: increment-{hsh}-num
+            label: num
+            type: int
+            default: 3
+        outputs:
+          out:
+            label: out
+            outputSource: increment-{hsh}/out
+            type: int
+        steps:
+          increment-{hsh}:
+            run: increment
+            in:
+                num:
+                    source: increment-{hsh}-num
+            out: [out]
+    """)
+
+def test_cwl_with_positional_parameter() -> None:
+    """Check whether we can move raw input to parameters.
+
+    Produces CWL for a call with a changeable raw value, that is converted
+    to a parameter, if and only if we are calling from outside a subworkflow.
+    """
+    with pytest.raises(TaskException) as _:
+        result = increment(3)
+    with set_configuration(allow_positional_args=True):
+        result = increment(3)
+        workflow = construct(result)
+        rendered = render(workflow)["__root__"]
+    num_param = list(workflow.find_parameters())[0]
+    hsh = hasher(("increment", ("num", f"int|:param:{num_param._.unique_name}")))
+
+    assert rendered == yaml.safe_load(f"""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs:
+          increment-{hsh}-num:
+            label: num
             type: int
             default: 3
         outputs:
@@ -187,7 +218,7 @@ def test_cwl_without_default() -> None:
 
     result = increment(num=my_param)
     workflow = construct(result)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
     hsh = hasher(("increment", ("num", "int|:param:my_param")))
 
     assert rendered == yaml.safe_load(f"""
@@ -217,7 +248,9 @@ def test_cwl_with_subworkflow() -> None:
     my_param = param("num", typ=int)
     result = increment(num=floor(num=triple_and_one(num=increment(num=my_param))))
     workflow = construct(result, simplify_ids=True)
-    rendered, subworkflows = render(workflow)
+    subworkflows = render(workflow)
+    rendered = subworkflows["__root__"]
+    del subworkflows["__root__"]
 
     assert len(subworkflows) == 1
     assert isinstance(subworkflows, dict)
@@ -233,7 +266,7 @@ def test_cwl_with_subworkflow() -> None:
         outputs:
           out:
             label: out
-            outputSource: increment-2/out
+            outputSource: increment-1/out
             type: int
         steps:
           floor-1:
@@ -242,13 +275,13 @@ def test_cwl_with_subworkflow() -> None:
                  source: triple_and_one-1/out
              out: [out]
              run: floor
-          increment-1:
+          increment-2:
              in:
                num:
                  source: num
              out: [out]
              run: increment
-          increment-2:
+          increment-1:
              in:
                num:
                  source: floor-1/out
@@ -257,7 +290,7 @@ def test_cwl_with_subworkflow() -> None:
           triple_and_one-1:
              in:
                num:
-                 source: increment-1/out
+                 source: increment-2/out
              out: [out]
              run: triple_and_one
     """)
@@ -269,14 +302,10 @@ def test_cwl_with_subworkflow() -> None:
           num:
             label: num
             type: int
-          sum-1-2-right:
-            default: 1
-            label: sum-1-2-right
-            type: int
         outputs:
           out:
             label: out
-            outputSource: sum-1-2/out
+            outputSource: sum-1-1/out
             type:
             - int
             - float
@@ -288,7 +317,7 @@ def test_cwl_with_subworkflow() -> None:
             out:
             - out
             run: double
-          sum-1-1:
+          sum-1-2:
             in:
               left:
                 source: double-1-1/out
@@ -297,12 +326,12 @@ def test_cwl_with_subworkflow() -> None:
             out:
             - out
             run: sum
-          sum-1-2:
+          sum-1-1:
             in:
               left:
-                source: sum-1-1/out
+                source: sum-1-2/out
               right:
-                source: sum-1-2-right
+                default: 1
             out:
             - out
             run: sum
@@ -316,26 +345,26 @@ def test_cwl_references() -> None:
     """
     result = double(num=increment(num=3))
     workflow = construct(result)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
     num_param = list(workflow.find_parameters())[0]
     hsh_increment = hasher(
-        ("increment", ("num", f"int|:param:{num_param.unique_name}"))
+        ("increment", ("num", f"int|:param:{num_param._.unique_name}"))
     )
-    hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}/out")))
+    hsh_double = hasher(("double", ("num", f"increment-{hsh_increment}")))
 
     assert rendered == yaml.safe_load(f"""
         cwlVersion: 1.2
         class: Workflow
         inputs:
           increment-{hsh_increment}-num:
-            label: increment-{hsh_increment}-num
+            label: num
             type: int
             default: 3
         outputs:
           out:
             label: out
             outputSource: double-{hsh_double}/out
-            type: 
+            type:
             - int
             - float
         steps:
@@ -361,25 +390,21 @@ def test_complex_cwl_references() -> None:
     """
     result = sum(left=double(num=increment(num=23)), right=mod10(num=increment(num=23)))
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
         class: Workflow
         inputs:
           increment-1-num:
-            label: increment-1-num
-            type: int
-            default: 23
-          increment-2-num:
-            label: increment-2-num
+            label: num
             type: int
             default: 23
         outputs:
           out:
             label: out
             outputSource: sum-1/out
-            type: 
+            type:
             - int
             - float
         steps:
@@ -389,17 +414,11 @@ def test_complex_cwl_references() -> None:
                 num:
                     source: increment-1-num
             out: [out]
-          increment-2:
-            run: increment
-            in:
-                num:
-                    source: increment-2-num
-            out: [out]
           double-1:
             run: double
             in:
                 num:
-                    source: increment-2/out
+                    source: increment-1/out
             out: [out]
           mod10-1:
             run: mod10
@@ -423,8 +442,10 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
     my_param = param("num", typ=int)
     result = increment(num=floor(num=triple_and_one(num=sum(left=my_param, right=3))))
     workflow = construct(result, simplify_ids=True)
-    rendered, subworkflows = render(workflow)
+    subworkflows = render(workflow)
+    rendered = subworkflows["__root__"]
 
+    del subworkflows["__root__"]
     assert len(subworkflows) == 1
     assert isinstance(subworkflows, dict)
     name, subworkflow = list(subworkflows.items())[0]
@@ -438,7 +459,7 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
             type: int
           sum-1-right:
             default: 3
-            label: sum-1-right
+            label: right
             type: int
         outputs:
           out:
@@ -484,14 +505,10 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
               int,
               float
             ]
-          sum-1-2-right:
-            default: 1
-            label: sum-1-2-right
-            type: int
         outputs:
           out:
             label: out
-            outputSource: sum-1-2/out
+            outputSource: sum-1-1/out
             type:
             - int
             - float
@@ -503,7 +520,7 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
             out:
             - out
             run: double
-          sum-1-1:
+          sum-1-2:
             in:
               left:
                 source: double-1-1/out
@@ -512,12 +529,12 @@ def test_cwl_with_subworkflow_and_raw_params() -> None:
             out:
             - out
             run: sum
-          sum-1-2:
+          sum-1-1:
             in:
               left:
-                source: sum-1-1/out
+                source: sum-1-2/out
               right:
-                source: sum-1-2-right
+                default: 1
             out:
             - out
             run: sum
@@ -531,8 +548,7 @@ def test_tuple_floats() -> None:
     """
     result = tuple_float_return()
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)
-    print(yaml.dump(rendered))
+    rendered = render(workflow)["__root__"]
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
         class: Workflow
@@ -541,11 +557,10 @@ def test_tuple_floats() -> None:
           out:
             label: out
             outputSource: tuple_float_return-1/out
-            type: 
-              items: 
-                - type: float
-                - type: float
-              type: array
+            items:
+              - float
+              - float
+            type: array
         steps:
           tuple_float_return-1:
             run: tuple_float_return

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -5,19 +5,23 @@ from typing import cast
 from dewret.workflow import Lazy
 from dewret.backends.backend_dask import lazy, run
 
+
 def inc_task(base: int) -> int:
     """Increments a value by one and returns it."""
     return 1 + base
 
+
 def add_task(left: int, right: int) -> int:
     """Adds two values and returns the result."""
     return left + right
+
 
 def test_can_run_task() -> None:
     """Check whether a dask task can run via `TaskManager`."""
     task: Lazy = lazy(inc_task)(base=3)
     incremented: int = cast(int, run(None, task))
     assert incremented == 4
+
 
 def test_missing_arguments_throw_error_in_dask() -> None:
     """Check whether a dask task can run via `TaskManager`."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,8 +2,9 @@
 
 import pytest
 from dewret.workflow import Task, Lazy
-from dewret.tasks import construct, task, nested_task, TaskException
-from ._lib.extra import increment  # noqa: F401
+from dewret.tasks import construct, task, workflow, TaskException
+from dewret.annotations import AtRender
+from ._lib.extra import increment, pi, reverse_list  # noqa: F401
 
 
 @task()  # This is expected to be the line number shown below.
@@ -12,10 +13,10 @@ def add_task(left: int, right: int) -> int:
     return left + right
 
 
-ADD_TASK_LINE_NO = 9
+ADD_TASK_LINE_NO: int = 10
 
 
-@nested_task()
+@workflow()
 def badly_add_task(left: int, right: int) -> int:
     """Badly attempts to add two numbers."""
     return add_task(left=left)  # type: ignore
@@ -36,14 +37,6 @@ class MyStrangeClass:
 
 
 @task()
-def pi() -> float:
-    """Get pi from math package."""
-    import math
-
-    return math.pi
-
-
-@task()
 def pi_exported_from_math() -> float:
     """Get pi from math package by name."""
     from math import pi
@@ -52,9 +45,9 @@ def pi_exported_from_math() -> float:
 
 
 @task()
-def test_recursive() -> float:
+def try_recursive() -> float:
     """Get pi from math package by name."""
-    return test_recursive()
+    return try_recursive()
 
 
 @task()
@@ -88,15 +81,15 @@ def pi_with_invisible_module_task() -> float:
     return extra.double(3.14 / 2)
 
 
-@nested_task()
+@workflow()
 def unacceptable_object_usage() -> int:
     """Invalid use of custom object within nested task."""
     return MyStrangeClass(add_task(left=3, right=4))  # type: ignore
 
 
-@nested_task()
-def unacceptable_nested_return(int_not_global: bool) -> int | Lazy:
-    """Bad nested_task that fails to return a task."""
+@workflow()
+def unacceptable_nested_return(int_not_global: AtRender[bool]) -> int | Lazy:
+    """Bad subworkflow that fails to return a task."""
     add_task(left=3, right=4)
     return 7 if int_not_global else ADD_TASK_LINE_NO
 
@@ -110,17 +103,16 @@ def test_missing_arguments_throw_error() -> None:
     WARNING: in keeping with Python principles, this does not error if types
     mismatch, but `mypy` should. You **must** type-check your code to catch these.
     """
-    result = add_task(left=3)  # type: ignore
     with pytest.raises(TaskException) as exc:
-        construct(result)
+        add_task(left=3)  # type: ignore
     end_section = str(exc.getrepr())[-500:]
     assert str(exc.value) == "missing a required argument: 'right'"
     assert "Task add_task declared in <module> at " in end_section
     assert f"test_errors.py:{ADD_TASK_LINE_NO}" in end_section
 
 
-def test_missing_arguments_throw_error_in_nested_task() -> None:
-    """Check whether omitting a required argument within a nested_task will give an error.
+def test_missing_arguments_throw_error_in_subworkflow() -> None:
+    """Check whether omitting a required argument within a subworkflow will give an error.
 
     Since we do not run the original function, it is up to dewret to check
     that the signature is, at least, acceptable to Python.
@@ -128,9 +120,8 @@ def test_missing_arguments_throw_error_in_nested_task() -> None:
     WARNING: in keeping with Python principles, this does not error if types
     mismatch, but `mypy` should. You **must** type-check your code to catch these.
     """
-    result = badly_add_task(left=3, right=4)
     with pytest.raises(TaskException) as exc:
-        construct(result)
+        badly_add_task(left=3, right=4)
     end_section = str(exc.getrepr())[-500:]
     assert str(exc.value) == "missing a required argument: 'right'"
     assert "def badly_add_task" in end_section
@@ -144,9 +135,8 @@ def test_positional_arguments_throw_error() -> None:
     We can use default and non-default arguments, but we expect them
     to _always_ be named.
     """
-    result = add_task(3, right=4)
     with pytest.raises(TaskException) as exc:
-        construct(result)
+        add_task(3, right=4)
     assert (
         str(exc.value)
         .strip()
@@ -154,21 +144,20 @@ def test_positional_arguments_throw_error() -> None:
     )
 
 
-def test_nesting_non_nested_tasks_throws_error() -> None:
-    """Ensure nesting is only allow in nested_tasks.
+def test_nesting_non_subworkflows_throws_error() -> None:
+    """Ensure nesting is only allow in subworkflows.
 
     Nested tasks must be evaluated at construction time, and there
     is no concept of task calls that are not resolved during construction, so
     a task should not be called inside a non-nested task.
     """
-    result = badly_wrap_task()
     with pytest.raises(TaskException) as exc:
-        construct(result)
+        badly_wrap_task()
     assert (
         str(exc.value)
         .strip()
         .startswith(
-            "You referenced a task add_task inside another task badly_wrap_task, but it is not a nested_task"
+            "You referenced a task add_task inside another task badly_wrap_task, but it is not a workflow"
         )
     )
 
@@ -195,19 +184,18 @@ def test_nesting_does_not_identify_imports_as_nesting() -> None:
         pi_hidden_by_math,
         pi_hidden_by_math_2,
     ]
-    bad = [test_recursive, pi_with_visible_module_task]
+    bad = [try_recursive, pi_with_visible_module_task]
     for tsk in bad:
-        result = tsk()
         with pytest.raises(TaskException) as exc:
-            construct(result)
+            tsk()
         assert str(exc.value).strip().startswith("You referenced a task")
     for tsk in good:
         result = tsk()
         construct(result)
 
 
-def test_normal_objects_cannot_be_used_in_nested_tasks() -> None:
-    """Most entities cannot appear in a nested_task, ensure we catch them.
+def test_normal_objects_cannot_be_used_in_subworkflows() -> None:
+    """Most entities cannot appear in a subworkflow, ensure we catch them.
 
     Since the logic in nested tasks has to be embedded explicitly in the workflow,
     complex types are not necessarily representable, and in most cases, we would not
@@ -215,34 +203,65 @@ def test_normal_objects_cannot_be_used_in_nested_tasks() -> None:
 
     Note: this may be mitigated with sympy support, to some extent.
     """
-    result = unacceptable_object_usage()
     with pytest.raises(TaskException) as exc:
-        construct(result)
+        unacceptable_object_usage()
     assert (
         str(exc.value)
-        == "Nested tasks must now only refer to global parameters, raw or tasks, not objects: MyStrangeClass"
+        == "Attempted to build a workflow from a return-value/result/expression with no references."
     )
 
 
-def test_nested_tasks_must_return_a_task() -> None:
+def test_subworkflows_must_return_a_task() -> None:
     """Ensure nested tasks are lazy-evaluatable.
 
     A graph only makes sense if the edges connect, and nested tasks must therefore chain.
     As such, a nested task must represent a real subgraph, and return a node to pull it into
     the main graph.
     """
-    result = unacceptable_nested_return(int_not_global=True)
     with pytest.raises(TaskException) as exc:
+        result = unacceptable_nested_return(int_not_global=True)
         construct(result)
     assert (
         str(exc.value)
-        == "Task unacceptable_nested_return returned output of type <class 'int'>, which is not a lazy function for this backend."
+        == "Attempted to build a workflow from a return-value/result/expression with no references."
     )
 
     result = unacceptable_nested_return(int_not_global=False)
+    construct(result)
+
+bad_num = 3
+good_num: int = 4
+
+def test_must_annotate_global() -> None:
+    """TODO: Docstrings."""
+    worse_num = 3
+
+    @workflow()
+    def check_annotation() -> int | float:
+        return increment(num=bad_num)
+
     with pytest.raises(TaskException) as exc:
-        construct(result)
+        check_annotation()
+
     assert (
         str(exc.value)
-        == "Task unacceptable_nested_return returned output of type <class 'int'>, which is not a lazy function for this backend."
+        == "Could not find a type annotation for bad_num for check_annotation"
     )
+
+    @workflow()
+    def check_annotation_2() -> int | float:
+        return increment(num=worse_num)
+
+    with pytest.raises(TaskException) as exc:
+        check_annotation_2()
+
+    assert (
+        str(exc.value)
+        == "Cannot use free variables - please put worse_num at the global scope"
+    )
+
+    @workflow()
+    def check_annotation_3() -> int | float:
+        return increment(num=good_num)
+
+    check_annotation_3()

--- a/tests/test_fieldable.py
+++ b/tests/test_fieldable.py
@@ -1,0 +1,410 @@
+"""Check field management works."""
+
+from __future__ import annotations
+import yaml
+from dataclasses import dataclass
+
+from typing import Unpack, TypedDict
+
+from dewret.tasks import task, construct, workflow
+from dewret.core import set_configuration
+from dewret.workflow import param, StepReference
+from dewret.renderers.cwl import render
+from dewret.annotations import Fixed
+
+from ._lib.extra import mod10, sum, pi
+
+
+@dataclass
+class Sides:
+    """A dataclass representing the sides with `left` and `right` integers."""
+
+    left: int
+    right: int
+
+
+SIDES: Sides = Sides(3, 6)
+
+
+@workflow()
+def sum_sides() -> float:
+    """Workflow that returns the sum of the `left` and `right` sides."""
+    return sum(left=SIDES.left, right=SIDES.right)
+
+
+def test_fields_of_parameters_usable() -> None:
+    """Test that fields of parameters can be used to construct and render a workflow correctly."""
+    result = sum_sides()
+    wkflw = construct(result, simplify_ids=True)
+    rendered = render(wkflw, allow_complex_types=True)["sum_sides-1"]
+
+    assert rendered == yaml.safe_load("""
+      class: Workflow
+      cwlVersion: 1.2
+      inputs:
+        SIDES:
+          label: SIDES
+          default:
+            left: 3
+            right: 6
+          type: record
+          fields:
+            left:
+              default: 3
+              label: left
+              type: int
+            right:
+              default: 6
+              label: right
+              type: int
+          label: SIDES
+      outputs:
+        out:
+          label: out
+          outputSource: sum-1-1/out
+          type:
+          - int
+          - float
+      steps:
+        sum-1-1:
+          in:
+            left:
+              source: SIDES/left
+            right:
+              source: SIDES/right
+          out:
+          - out
+          run: sum
+    """)
+
+
+@dataclass
+class MyDataclass:
+    """A dataclass with nested references to itself, containing `left` and `right` fields."""
+
+    left: int
+    right: "MyDataclass"
+
+
+def test_can_get_field_reference_from_parameter() -> None:
+    """Test that field references can be retrieved from a parameter when constructing a workflow."""
+    my_param = param("my_param", typ=MyDataclass)
+    result = sum(
+        left=my_param.left, right=sum(left=my_param.right.left, right=my_param.left)
+    )
+    wkflw = construct(result, simplify_ids=True)
+    params = {(str(p), p.__type__) for p in wkflw.find_parameters()}
+
+    assert params == {("my_param", MyDataclass)}
+    rendered = render(wkflw, allow_complex_types=True)["__root__"]
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          my_param:
+            label: my_param
+            type: MyDataclass
+        outputs:
+          out:
+            label: out
+            outputSource: sum-1/out
+            type:
+            - int
+            - float
+        steps:
+          sum-1:
+            in:
+              left:
+                source: my_param/left
+              right:
+                source: sum-2/out
+            out:
+            - out
+            run: sum
+          sum-2:
+            in:
+              left:
+                source: my_param/right/left
+              right:
+                source: my_param/left
+            out:
+            - out
+            run: sum
+    """)
+
+
+def test_can_get_field_reference_if_parent_type_has_field() -> None:
+    """Test that a field reference is retrievable if the parent type has that field."""
+
+    @dataclass
+    class MyDataclass:
+        left: int
+
+    my_param = param("my_param", typ=MyDataclass)
+    result = sum(left=my_param.left, right=my_param.left)
+    wkflw = construct(result, simplify_ids=True)
+    param_reference = list(wkflw.find_parameters())[0]
+
+    assert str(param_reference.left) == "my_param/left"
+    assert param_reference.left.__type__ == int
+
+
+def test_can_get_go_upwards_from_a_field_reference() -> None:
+    """Test that it's possible to move upwards in the hierarchy from a field reference."""
+
+    @dataclass
+    class MyDataclass:
+        left: int
+        right: "MyDataclass"
+
+    my_param = param("my_param", typ=MyDataclass)
+    result = sum(left=my_param.left, right=my_param.left)
+    construct(result, simplify_ids=True)
+
+    back = my_param.right.left.__field_up__()  # type: ignore
+    assert str(back) == "my_param/right"
+    assert back.__type__ == MyDataclass
+
+
+def test_can_get_field_references_from_dataclass() -> None:
+    """Test that field references can be extracted from a dataclass and used in workflows."""
+
+    @dataclass
+    class MyDataclass:
+        left: int
+        right: float
+
+    @workflow()
+    def test_dataclass(my_dataclass: MyDataclass) -> MyDataclass:
+        result: MyDataclass = MyDataclass(left=mod10(num=my_dataclass.left), right=pi())
+        return result
+
+    @workflow()
+    def get_left(my_dataclass: MyDataclass) -> int:
+        return my_dataclass.left
+
+    result = get_left(
+        my_dataclass=test_dataclass(my_dataclass=MyDataclass(left=3, right=4.0))
+    )
+    wkflw = construct(result, simplify_ids=True)
+
+    assert isinstance(wkflw.result, StepReference)
+    assert str(wkflw.result) == "get_left-1"
+    assert wkflw.result.__type__ == int
+
+
+class MyDict(TypedDict):
+    """A typed dictionary with `left` as an integer and `right` as a float."""
+
+    left: int
+    right: float
+
+
+def test_can_get_field_references_from_typed_dict() -> None:
+    """Test that field references can be extracted from a custom typed dictionary and used in workflows."""
+
+    @workflow()
+    def test_dict(**my_dict: Unpack[MyDict]) -> MyDict:
+        result: MyDict = {"left": mod10(num=my_dict["left"]), "right": pi()}
+        return result
+
+    result = test_dict(left=3, right=4.0)
+    wkflw = construct(result, simplify_ids=True)
+
+    assert isinstance(wkflw.result, StepReference)
+    assert str(wkflw.result["left"]) == "test_dict-1/left"
+    assert wkflw.result["left"].__type__ == int
+
+
+@dataclass
+class MyListWrapper:
+    """A dataclass that wraps a list of integers."""
+
+    my_list: list[int]
+
+
+def test_can_iterate() -> None:
+    """Test iteration over a list of tasks and validate positional argument handling."""
+
+    @task()
+    def test_task(alpha: int, beta: float, charlie: bool) -> int:
+        """Task that adds `alpha` and `beta` and returns the integer result."""
+        return int(alpha + beta)
+
+    @task()
+    def test_list() -> list[int | float]:
+        """Task that returns a list containing an integer and a float."""
+        return [1, 2.0]
+
+    @workflow()
+    def test_iterated() -> int:
+        """Workflow that tests task iteration over a list."""
+        # We ignore the type as mypy cannot confirm that the length and types match the args.
+        return test_task(*test_list())  # type: ignore
+
+    with set_configuration(allow_positional_args=True, flatten_all_nested=True):
+        result = test_iterated()
+        wkflw = construct(result, simplify_ids=True)
+
+    rendered = render(wkflw, allow_complex_types=True)["__root__"]
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs: {}
+        outputs:
+          out:
+            label: out
+            outputSource: test_task-1/out
+            type: int
+        steps:
+          test_list-1:
+            in: {}
+            out:
+            - out
+            run: test_list
+          test_task-1:
+            in:
+              alpha:
+                source: test_list-1[0]
+              beta:
+                source: test_list-1[1]
+              charlie:
+                source: test_list-1[2]
+            out:
+            - out
+            run: test_task
+    """)
+
+    assert isinstance(wkflw.result, StepReference)
+    assert wkflw.result._.step.positional_args == {
+        "alpha": True,
+        "beta": True,
+        "charlie": True,
+    }
+
+    @task()
+    def test_list_2() -> MyListWrapper:
+        """Task that returns a `MyListWrapper` containing a list of integers."""
+        return MyListWrapper(my_list=[1, 2])
+
+    @workflow()
+    def test_iterated_2(my_wrapper: MyListWrapper) -> int:
+        """Workflow that tests iteration over a list in a `MyListWrapper`."""
+        # mypy cannot confirm argument types match.
+        return test_task(*my_wrapper.my_list)  # type: ignore
+
+    with set_configuration(allow_positional_args=True, flatten_all_nested=True):
+        result = test_iterated_2(my_wrapper=test_list_2())
+        wkflw = construct(result, simplify_ids=True)
+
+    @task()
+    def test_list_3() -> Fixed[list[tuple[int, int]]]:
+        """Task that returns a list of integer tuples wrapped in a `dewret.annotations.Fixed` type."""
+        return [(0, 1), (2, 3)]
+
+    @workflow()
+    def test_iterated_3(param: Fixed[list[tuple[int, int]]]) -> int:
+        """Workflow that iterates over a list of integer tuples and performs operations."""
+        # mypy cannot confirm argument types match.
+        retval = mod10(*test_list_3()[0])  # type: ignore
+        for pair in param:
+            a, b = pair
+            retval += a + b
+        return mod10(retval)
+
+    with set_configuration(allow_positional_args=True, flatten_all_nested=True):
+        result = test_iterated_3(param=[(0, 1), (2, 3)])
+        wkflw = construct(result, simplify_ids=True)
+
+    rendered = render(wkflw, allow_complex_types=True)["__root__"]
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          param:
+            default:
+            - - 0
+              - 1
+            - - 2
+              - 3
+            items: array
+            label: param
+            type: array
+        outputs:
+          out:
+            label: out
+            outputSource: mod10-2/out
+            type: int
+        steps:
+          mod10-1:
+            in:
+              num:
+                source: test_list_3-1[0][0]
+            out:
+            - out
+            run: mod10
+          mod10-2:
+            in:
+              num:
+                valueFrom: $(inputs.param[0][0] + inputs.param[0][1] + inputs.param[1][0] + inputs.param[1][1] + self)
+                source: mod10-1/out
+            out:
+            - out
+            run: mod10
+          test_list_3-1:
+            in: {}
+            out:
+            - out
+            run: test_list_3
+    """)
+
+
+def test_can_use_plain_dict_fields() -> None:
+    """Test the use of plain dictionary fields in workflows."""
+
+    @workflow()
+    def test_dict(left: int, right: float) -> dict[str, float | int]:
+        result: dict[str, float | int] = {"left": mod10(num=left), "right": pi()}
+        return result
+
+    with set_configuration(allow_plain_dict_fields=True):
+        result = test_dict(left=3, right=4.0)
+        wkflw = construct(result, simplify_ids=True)
+        assert isinstance(wkflw.result, StepReference)
+        assert str(wkflw.result["left"]) == "test_dict-1/left"
+        assert wkflw.result["left"].__type__ == int | float
+
+
+@dataclass
+class IndexTest:
+    """A dataclass for testing indexed fields, containing a `left` field that is a list of integers."""
+
+    left: Fixed[list[int]]
+
+
+def test_can_configure_field_separator() -> None:
+    """Test the ability to configure the field separator in workflows."""
+
+    @task()
+    def test_sep() -> IndexTest:
+        return IndexTest(left=[3])
+
+    with set_configuration(field_index_types="int"):
+        result = test_sep().left[0]
+        wkflw = construct(result, simplify_ids=True)
+        render(wkflw, allow_complex_types=True)["__root__"]
+        assert str(wkflw.result) == "test_sep-1/left[0]"
+
+    with set_configuration(field_index_types="int,str"):
+        result = test_sep().left[0]
+        wkflw = construct(result, simplify_ids=True)
+        render(wkflw, allow_complex_types=True)["__root__"]
+        assert str(wkflw.result) == "test_sep-1[left][0]"
+
+    with set_configuration(field_index_types=""):
+        result = test_sep().left[0]
+        wkflw = construct(result, simplify_ids=True)
+        render(wkflw, allow_complex_types=True)["__root__"]
+        assert str(wkflw.result) == "test_sep-1/left/0"

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -289,7 +289,9 @@ def test_pair_can_be_returned_from_step() -> None:
 def test_list_can_be_returned_from_step() -> None:
     """Tests whether a task can insert result fields into other steps."""
     with set_configuration(flatten_all_nested=True):
-        workflow = construct(list_cast(iterable=algorithm_with_pair()), simplify_ids=True)
+        workflow = construct(
+            list_cast(iterable=algorithm_with_pair()), simplify_ids=True
+        )
         rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""

--- a/tests/test_multiresult_steps.py
+++ b/tests/test_multiresult_steps.py
@@ -4,7 +4,8 @@ import yaml
 from attr import define
 from dataclasses import dataclass
 from typing import Iterable
-from dewret.tasks import task, construct, nested_task
+from dewret.tasks import task, construct, workflow
+from dewret.core import set_configuration
 from dewret.renderers.cwl import render
 
 STARTING_NUMBER: int = 23
@@ -44,19 +45,19 @@ def pair(left: int, right: float) -> tuple[int, float]:
     return (left, right)
 
 
-@nested_task()
+@workflow()
 def algorithm() -> float:
     """Sum two split values."""
     return combine(left=split().first, right=split().second)
 
 
-@nested_task()
+@workflow()
 def algorithm_with_pair() -> tuple[int, float]:
     """Pairs two split dataclass values."""
     return pair(left=split_into_dataclass().first, right=split_into_dataclass().second)
 
 
-@nested_task()
+@workflow()
 def algorithm_with_dataclasses() -> float:
     """Sums two split dataclass values."""
     return combine(
@@ -76,13 +77,13 @@ def split_into_dataclass() -> SplitResultDataclass:
     return SplitResultDataclass(first=1, second=2)
 
 
-def test_nested_task() -> None:
+def test_subworkflow() -> None:
     """Check whether we can link between multiple steps and have parameters.
 
     Produces CWL that has references between multiple steps.
     """
     workflow = construct(split(), simplify_ids=True)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -114,10 +115,10 @@ def test_nested_task() -> None:
     """)
 
 
-def test_field_of_nested_task() -> None:
+def test_field_of_subworkflow() -> None:
     """Tests whether a directly-output nested task can have fields."""
     workflow = construct(split().first, simplify_ids=True)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -142,10 +143,10 @@ def test_field_of_nested_task() -> None:
     """)
 
 
-def test_field_of_nested_task_into_dataclasses() -> None:
+def test_field_of_subworkflow_into_dataclasses() -> None:
     """Tests whether a directly-output nested task can have fields."""
     workflow = construct(split_into_dataclass().first, simplify_ids=True)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -170,10 +171,11 @@ def test_field_of_nested_task_into_dataclasses() -> None:
     """)
 
 
-def test_complex_field_of_nested_task() -> None:
+def test_complex_field_of_subworkflow() -> None:
     """Tests whether a task can sum complex structures."""
-    workflow = construct(algorithm(), simplify_ids=True)
-    rendered = render(workflow)
+    with set_configuration(flatten_all_nested=True):
+        workflow = construct(algorithm(), simplify_ids=True)
+        rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -206,11 +208,12 @@ def test_complex_field_of_nested_task() -> None:
     """)
 
 
-def test_complex_field_of_nested_task_with_dataclasses() -> None:
+def test_complex_field_of_subworkflow_with_dataclasses() -> None:
     """Tests whether a task can insert result fields into other steps."""
-    result = algorithm_with_dataclasses()
-    workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)
+    with set_configuration(flatten_all_nested=True):
+        result = algorithm_with_dataclasses()
+        workflow = construct(result, simplify_ids=True)
+        rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -245,8 +248,9 @@ def test_complex_field_of_nested_task_with_dataclasses() -> None:
 
 def test_pair_can_be_returned_from_step() -> None:
     """Tests whether a task can insert result fields into other steps."""
-    workflow = construct(algorithm_with_pair(), simplify_ids=True)
-    rendered = render(workflow)
+    with set_configuration(flatten_all_nested=True):
+        workflow = construct(algorithm_with_pair(), simplify_ids=True)
+        rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -256,11 +260,10 @@ def test_pair_can_be_returned_from_step() -> None:
           out:
             label: out
             outputSource: pair-1/out
-            type: 
-              items: 
-                - type: int
-                - type: float
-              type: array
+            items:
+              - int
+              - float
+            type: array
         steps:
           pair-1:
             in:
@@ -285,8 +288,9 @@ def test_pair_can_be_returned_from_step() -> None:
 
 def test_list_can_be_returned_from_step() -> None:
     """Tests whether a task can insert result fields into other steps."""
-    workflow = construct(list_cast(iterable=algorithm_with_pair()), simplify_ids=True)
-    rendered = render(workflow)
+    with set_configuration(flatten_all_nested=True):
+        workflow = construct(list_cast(iterable=algorithm_with_pair()), simplify_ids=True)
+        rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         class: Workflow
@@ -296,9 +300,8 @@ def test_list_can_be_returned_from_step() -> None:
           out:
             label: out
             outputSource: list_cast-1/out
-            type:
-              items: float
-              type: array
+            items: float
+            type: array
         steps:
           list_cast-1:
             in:

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1,0 +1,56 @@
+"""Check complex nested structures and expressions can mix."""
+
+import yaml
+import math
+from dewret.workflow import param
+from dewret.tasks import construct
+from dewret.renderers.cwl import render
+
+from ._lib.extra import reverse_list, max_list
+
+
+def test_can_supply_nested_raw() -> None:
+    """TODO: The structures are important for future CWL rendering."""
+    pi = param("pi", math.pi)
+    result = reverse_list(to_sort=[1.0, 3.0, pi])
+    workflow = construct(max_list(lst=result + result), simplify_ids=True)
+    # assert workflow.find_parameters() == {
+    #    pi
+    # }
+
+    # NB: This is not currently usefully renderable in CWL.
+    # However, the structures are important for future CWL rendering.
+
+    rendered = render(workflow)["__root__"]
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          pi:
+            default: 3.141592653589793
+            label: pi
+            type: float
+        outputs:
+          out:
+            label: out
+            outputSource: max_list-1/out
+            type:
+            - int
+            - float
+        steps:
+          max_list-1:
+            in:
+              lst:
+                source: reverse_list-1/out
+                valueFrom: $(2*self)
+            out:
+            - out
+            run: max_list
+          reverse_list-1:
+            in:
+              to_sort:
+                valueFrom: $((1.0, 3.0, inputs.pi))
+            out:
+            - out
+            run: reverse_list
+    """)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -23,7 +23,7 @@ def test_cwl_parameters() -> None:
     """
     result = rotate(num=3)
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
 
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
@@ -34,7 +34,7 @@ def test_cwl_parameters() -> None:
             type: int
             default: 3
           rotate-1-num:
-            label: rotate-1-num
+            label: num
             type: int
             default: 3
         outputs:
@@ -62,7 +62,8 @@ def test_complex_parameters() -> None:
     num = param("numx", 23)
     result = sum(left=double(num=rotate(num=num)), right=rotate(num=rotate(num=23)))
     workflow = construct(result, simplify_ids=True)
-    rendered = render(workflow)
+    rendered = render(workflow)["__root__"]
+
     assert rendered == yaml.safe_load("""
         cwlVersion: 1.2
         class: Workflow
@@ -75,8 +76,8 @@ def test_complex_parameters() -> None:
             label: numx
             type: int
             default: 23
-          rotate-1-num:
-            label: rotate-1-num
+          rotate-2-num:
+            label: num
             type: int
             default: 23
         outputs:
@@ -91,7 +92,7 @@ def test_complex_parameters() -> None:
                 INPUT_NUM:
                     source: INPUT_NUM
                 num:
-                    source: rotate-1-num
+                    source: rotate-2/out
             out: [out]
           double-1:
             run: double
@@ -105,7 +106,7 @@ def test_complex_parameters() -> None:
                 INPUT_NUM:
                     source: INPUT_NUM
                 num:
-                    source: rotate-1/out
+                    source: rotate-2-num
             out: [out]
           rotate-3:
             run: rotate
@@ -121,6 +122,6 @@ def test_complex_parameters() -> None:
                 left:
                     source: double-1/out
                 right:
-                    source: rotate-2/out
+                    source: rotate-1/out
             out: [out]
     """)

--- a/tests/test_render_module.py
+++ b/tests/test_render_module.py
@@ -53,7 +53,7 @@ def test_can_load_cwl_render_module() -> None:
     render = get_render_method(frender_py)
     assert render(workflow) == {
         "__root__": "{'cwlVersion': 1.2, 'class': 'Workflow', 'inputs': {'increment-1-num': {'label': 'num', 'type': 'int', 'default': 3}}, 'outputs': {'out': {'label': 'out', 'type': ['int', 'float'], 'outputSource': 'triple_and_one-1/out'}}, 'steps': {'increment-1': {'run': 'increment', 'in': {'num': {'source': 'increment-1-num'}}, 'out': ['out']}, 'triple_and_one-1': {'run': 'triple_and_one', 'in': {'num': {'source': 'increment-1/out'}}, 'out': ['out']}}}",
-        "triple_and_one-1": "{'cwlVersion': 1.2, 'class': 'Workflow', 'inputs': {'num': {'label': 'num', 'type': 'int'}}, 'outputs': {'out': {'label': 'out', 'type': ['int', 'float'], 'outputSource': 'sum-1-1/out'}}, 'steps': {'double-1-1': {'run': 'double', 'in': {'num': {'source': 'num'}}, 'out': ['out']}, 'sum-1-1': {'run': 'sum', 'in': {'left': {'source': 'sum-1-2/out'}, 'right': {'default': 1}}, 'out': ['out']}, 'sum-1-2': {'run': 'sum', 'in': {'left': {'source': 'double-1-1/out'}, 'right': {'source': 'num'}}, 'out': ['out']}}}"
+        "triple_and_one-1": "{'cwlVersion': 1.2, 'class': 'Workflow', 'inputs': {'num': {'label': 'num', 'type': 'int'}}, 'outputs': {'out': {'label': 'out', 'type': ['int', 'float'], 'outputSource': 'sum-1-1/out'}}, 'steps': {'double-1-1': {'run': 'double', 'in': {'num': {'source': 'num'}}, 'out': ['out']}, 'sum-1-1': {'run': 'sum', 'in': {'left': {'source': 'sum-1-2/out'}, 'right': {'default': 1}}, 'out': ['out']}, 'sum-1-2': {'run': 'sum', 'in': {'left': {'source': 'double-1-1/out'}, 'right': {'source': 'num'}}, 'out': ['out']}}}",
     }
 
 
@@ -61,17 +61,21 @@ def test_get_correct_import_error_if_unable_to_load_render_module() -> None:
     """Check if the correct import error will be logged if unable to load render module."""
     unfrender_py = Path(__file__).parent / "_lib/unfrender.py"
     with pytest.raises(ModuleNotFoundError) as exc:
-      get_render_method(unfrender_py)
+        get_render_method(unfrender_py)
 
     entry = exc.traceback[-1]
-    assert Path(entry.path).resolve() == (
-        Path(__file__).parent / "_lib" / "unfrender.py"
-    ).resolve()
+    assert (
+        Path(entry.path).resolve()
+        == (Path(__file__).parent / "_lib" / "unfrender.py").resolve()
+    )
     assert entry.relline == 12
     assert "No module named 'extra'" in str(exc.value)
 
     nonfrender_py = Path(__file__).parent / "_lib/nonfrender.py"
     with pytest.raises(NotImplementedError) as nexc:
-      get_render_method(nonfrender_py)
+        get_render_method(nonfrender_py)
 
-    assert "This render module neither seems to be a structured nor a raw render module" in str(nexc.value)
+    assert (
+        "This render module neither seems to be a structured nor a raw render module"
+        in str(nexc.value)
+    )

--- a/tests/test_render_module.py
+++ b/tests/test_render_module.py
@@ -1,0 +1,77 @@
+"""Check renderers can be imported live."""
+
+import pytest
+from pathlib import Path
+from dewret.tasks import construct
+from dewret.render import get_render_method
+
+from ._lib.extra import increment, triple_and_one
+
+
+def test_can_load_render_module() -> None:
+    """Checks if we can load a render module."""
+    result = triple_and_one(num=increment(num=3))
+    workflow = construct(result, simplify_ids=True)
+    workflow._name = "Fred"
+
+    frender_py = Path(__file__).parent / "_lib/frender.py"
+    render = get_render_method(frender_py)
+
+    assert render(workflow) == {
+        "__root__": """
+I found a workflow called Fred.
+It has 2 steps!
+They are:
+* Something called increment-1
+
+* A portal called triple_and_one-1 to another workflow,
+  whose name is triple_and_one
+
+It probably got made with JUMP=1.0
+""",
+        "triple_and_one-1": """
+I found a workflow called triple_and_one.
+It has 3 steps!
+They are:
+* Something called double-1-1
+
+* Something called sum-1-1
+
+* Something called sum-1-2
+
+It probably got made with JUMP=1.0
+""",
+    }
+
+
+def test_can_load_cwl_render_module() -> None:
+    """Checks if we can load a render module."""
+    result = triple_and_one(num=increment(num=3))
+    workflow = construct(result, simplify_ids=True)
+
+    frender_py = Path(__file__).parent.parent / "src/dewret/renderers/cwl.py"
+    render = get_render_method(frender_py)
+    assert render(workflow) == {
+        "__root__": "{'cwlVersion': 1.2, 'class': 'Workflow', 'inputs': {'increment-1-num': {'label': 'num', 'type': 'int', 'default': 3}}, 'outputs': {'out': {'label': 'out', 'type': ['int', 'float'], 'outputSource': 'triple_and_one-1/out'}}, 'steps': {'increment-1': {'run': 'increment', 'in': {'num': {'source': 'increment-1-num'}}, 'out': ['out']}, 'triple_and_one-1': {'run': 'triple_and_one', 'in': {'num': {'source': 'increment-1/out'}}, 'out': ['out']}}}",
+        "triple_and_one-1": "{'cwlVersion': 1.2, 'class': 'Workflow', 'inputs': {'num': {'label': 'num', 'type': 'int'}}, 'outputs': {'out': {'label': 'out', 'type': ['int', 'float'], 'outputSource': 'sum-1-1/out'}}, 'steps': {'double-1-1': {'run': 'double', 'in': {'num': {'source': 'num'}}, 'out': ['out']}, 'sum-1-1': {'run': 'sum', 'in': {'left': {'source': 'sum-1-2/out'}, 'right': {'default': 1}}, 'out': ['out']}, 'sum-1-2': {'run': 'sum', 'in': {'left': {'source': 'double-1-1/out'}, 'right': {'source': 'num'}}, 'out': ['out']}}}"
+    }
+
+
+def test_get_correct_import_error_if_unable_to_load_render_module() -> None:
+    """Check if the correct import error will be logged if unable to load render module."""
+    unfrender_py = Path(__file__).parent / "_lib/unfrender.py"
+    with pytest.raises(ModuleNotFoundError) as exc:
+      get_render_method(unfrender_py)
+
+    entry = exc.traceback[-1]
+    assert Path(entry.path).resolve() == (
+        Path(__file__).parent / "_lib" / "unfrender.py"
+    ).resolve()
+    assert entry.relline == 12
+    assert "No module named 'extra'" in str(exc.value)
+
+    nonfrender_py = Path(__file__).parent / "_lib/nonfrender.py"
+    with pytest.raises(NotImplementedError) as nexc:
+      get_render_method(nonfrender_py)
+
+    assert "This render module neither seems to be a structured nor a raw render module" in str(nexc.value)

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -3,21 +3,23 @@
 from typing import Callable
 from queue import Queue
 import yaml
-from dewret.tasks import construct, subworkflow, task, factory
+from dewret.tasks import construct, workflow, task, factory
+from dewret.core import set_configuration
 from dewret.renderers.cwl import render
 from dewret.workflow import param
+from attrs import define
 
-from ._lib.extra import increment, sum
+from ._lib.extra import increment, sum, pi
 
-CONSTANT = 3
+CONSTANT: int = 3
 
-QueueFactory: Callable[..., "Queue[int]"] = factory(Queue)
+QueueFactory: Callable[..., Queue[int]] = factory(Queue)
 
-GLOBAL_QUEUE = QueueFactory()
+GLOBAL_QUEUE: Queue[int] = QueueFactory()
 
 
 @task()
-def pop(queue: "Queue[int]") -> int:
+def pop(queue: Queue[int]) -> int:
     """Remove element of a queue."""
     return queue.get()
 
@@ -29,39 +31,97 @@ def to_int(num: int | float) -> int:
 
 
 @task()
-def add_and_queue(num: int, queue: "Queue[int]") -> "Queue[int]":
+def add_and_queue(num: int, queue: Queue[int]) -> Queue[int]:
     """Add a global constant to a number."""
     queue.put(num)
     return queue
 
 
-@subworkflow()
-def make_queue(num: int | float) -> "Queue[int]":
+@workflow()
+def make_queue(num: int | float) -> Queue[int]:
     """Add a number to a queue."""
     queue = QueueFactory()
     return add_and_queue(num=to_int(num=num), queue=queue)
 
 
-@subworkflow()
-def get_global_queue(num: int | float) -> "Queue[int]":
+@workflow()
+def get_global_queue(num: int | float) -> Queue[int]:
     """Add a number to a global queue."""
     return add_and_queue(num=to_int(num=num), queue=GLOBAL_QUEUE)
 
 
-@subworkflow()
+@workflow()
+def get_global_queues(num: int | float) -> list[Queue[int] | int]:
+    """Add a number to a global queue."""
+    return [
+        add_and_queue(num=to_int(num=num), queue=GLOBAL_QUEUE),
+        add_constant(num=num),
+    ]
+
+
+@workflow()
 def add_constant(num: int | float) -> int:
     """Add a global constant to a number."""
     return to_int(num=sum(left=num, right=CONSTANT))
+
+
+@workflow()
+def add_constants(num: int | float) -> int:
+    """Add a global constant to a number."""
+    return to_int(num=sum(left=sum(left=num, right=CONSTANT), right=CONSTANT))
+
+
+@workflow()
+def get_values(num: int | float) -> tuple[int | float, int]:
+    """Add a global constant to a number."""
+    return (sum(left=num, right=CONSTANT), add_constant(CONSTANT))
+
+
+def test_cwl_for_pairs() -> None:
+    """Check whether we can produce CWL of pairs."""
+
+    @workflow()
+    def pair_pi() -> tuple[float, float]:
+        return pi(), pi()
+
+    with set_configuration(flatten_all_nested=True):
+        result = pair_pi()
+        wkflw = construct(result, simplify_ids=True)
+    rendered = render(wkflw)["__root__"]
+
+    assert rendered == yaml.safe_load("""
+        cwlVersion: 1.2
+        class: Workflow
+        inputs: {}
+        outputs: [
+          {
+            label: out,
+            outputSource: pi-1/out,
+            type: float
+          },
+          {
+            label: out,
+            outputSource: pi-1/out,
+            type: float
+          }
+        ]
+        steps:
+          pi-1:
+            run: pi
+            in: {}
+            out: [out]
+    """)
 
 
 def test_subworkflows_can_use_globals() -> None:
     """Produce a subworkflow that uses a global."""
     my_param = param("num", typ=int)
     result = increment(num=add_constant(num=increment(num=my_param)))
-    workflow = construct(result, simplify_ids=True)
-    rendered, subworkflows = render(workflow)
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw)
+    rendered = subworkflows["__root__"]
 
-    assert len(subworkflows) == 1
+    assert len(subworkflows) == 2
     assert isinstance(subworkflows, dict)
 
     assert rendered == yaml.safe_load("""
@@ -78,16 +138,16 @@ def test_subworkflows_can_use_globals() -> None:
         outputs:
           out:
             label: out
-            outputSource: increment-2/out
+            outputSource: increment-1/out
             type: int
         steps:
-          increment-1:
+          increment-2:
              in:
                num:
                  source: num
              out: [out]
              run: increment
-          increment-2:
+          increment-1:
              in:
                num:
                  source: add_constant-1/out
@@ -98,7 +158,7 @@ def test_subworkflows_can_use_globals() -> None:
                CONSTANT:
                  source: CONSTANT
                num:
-                 source: increment-1/out
+                 source: increment-2/out
              out: [out]
              run: add_constant
     """)
@@ -108,10 +168,11 @@ def test_subworkflows_can_use_factories() -> None:
     """Produce a subworkflow that uses a factory."""
     my_param = param("num", typ=int)
     result = pop(queue=make_queue(num=increment(num=my_param)))
-    workflow = construct(result, simplify_ids=True)
-    rendered, subworkflows = render(workflow, allow_complex_types=True)
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
 
-    assert len(subworkflows) == 1
+    assert len(subworkflows) == 2
     assert isinstance(subworkflows, dict)
 
     assert rendered == yaml.safe_load("""
@@ -152,10 +213,11 @@ def test_subworkflows_can_use_global_factories() -> None:
     """Check whether we can produce a subworkflow that uses a global factory."""
     my_param = param("num", typ=int)
     result = pop(queue=get_global_queue(num=increment(num=my_param)))
-    workflow = construct(result, simplify_ids=True)
-    rendered, subworkflows = render(workflow, allow_complex_types=True)
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
 
-    assert len(subworkflows) == 1
+    assert len(subworkflows) == 2
     assert isinstance(subworkflows, dict)
 
     assert rendered == yaml.safe_load("""
@@ -165,6 +227,9 @@ def test_subworkflows_can_use_global_factories() -> None:
           num:
             label: num
             type: int
+          GLOBAL_QUEUE:
+            label: GLOBAL_QUEUE
+            type: Queue
         outputs:
           out:
             label: out
@@ -181,6 +246,8 @@ def test_subworkflows_can_use_global_factories() -> None:
              in:
                num:
                  source: increment-1/out
+               GLOBAL_QUEUE:
+                 source: GLOBAL_QUEUE
              out: [out]
              run: get_global_queue
           pop-1:
@@ -189,4 +256,376 @@ def test_subworkflows_can_use_global_factories() -> None:
                  source: get_global_queue-1/out
              out: [out]
              run: pop
+    """)
+
+
+def test_subworkflows_can_return_lists() -> None:
+    """Check whether we can produce a subworkflow that returns a list."""
+    my_param = param("num", typ=int)
+    result = get_global_queues(num=increment(num=my_param))
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
+    del subworkflows["__root__"]
+
+    assert len(subworkflows) == 2
+    assert isinstance(subworkflows, dict)
+    osubworkflows = sorted(list(subworkflows.items()))
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+          CONSTANT:
+            label: CONSTANT
+            default: 3
+            type: int
+          GLOBAL_QUEUE:
+            label: GLOBAL_QUEUE
+            type: Queue
+        outputs:
+          out:
+            label: out
+            items:
+            - Queue
+            - int
+            outputSource: get_global_queues-1/out
+            type: array
+        steps:
+          increment-1:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          get_global_queues-1:
+             in:
+               num:
+                 source: increment-1/out
+               CONSTANT:
+                 source: CONSTANT
+               GLOBAL_QUEUE:
+                 source: GLOBAL_QUEUE
+             out: [out]
+             run: get_global_queues
+    """)
+
+    assert osubworkflows[0] == (
+        "add_constant-1-1",
+        yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+          CONSTANT:
+            default: 3
+            label: CONSTANT
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: to_int-1-1-1/out
+            type: int
+        steps:
+          sum-1-1-1:
+            in:
+              left:
+                source: num
+              right:
+                source: CONSTANT
+            out:
+            - out
+            run: sum
+          to_int-1-1-1:
+            in:
+              num:
+                source: sum-1-1-1/out
+            out:
+            - out
+            run: to_int
+    """),
+    )
+
+    assert osubworkflows[1] == (
+        "get_global_queues-1",
+        yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          CONSTANT:
+            default: 3
+            label: CONSTANT
+            type: int
+          num:
+            label: num
+            type: int
+          GLOBAL_QUEUE:
+            label: GLOBAL_QUEUE
+            type: Queue
+        outputs:
+          - label: out
+            outputSource: add_and_queue-1-1/out
+            type: Queue
+          - label: out
+            outputSource: add_constant-1-1/out
+            type: int
+        steps:
+          add_and_queue-1-1:
+            in:
+              num:
+                source: to_int-1-1/out
+              queue:
+                source: GLOBAL_QUEUE
+            out:
+            - out
+            run: add_and_queue
+          add_constant-1-1:
+            in:
+              CONSTANT:
+                source: CONSTANT
+              num:
+                source: num
+            out:
+            - out
+            run: add_constant
+          to_int-1-1:
+            in:
+              num:
+                source: num
+            out:
+            - out
+            run: to_int
+    """),
+    )
+
+
+def test_can_merge_workflows() -> None:
+    """Check whether we can merge workflows."""
+    my_param = param("num", typ=int)
+    value = to_int(num=increment(num=my_param))
+    result = sum(left=value, right=increment(num=value))
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw, allow_complex_types=True)
+    rendered = subworkflows["__root__"]
+    del subworkflows["__root__"]
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: sum-1/out
+            type: [
+              int,
+              float
+            ]
+        steps:
+          increment-1:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          increment-2:
+             in:
+               num:
+                 source: to_int-1/out
+             out: [out]
+             run: increment
+          sum-1:
+             in:
+               left:
+                 source: to_int-1/out
+               right:
+                 source: increment-2/out
+             out: [out]
+             run: sum
+          to_int-1:
+             in:
+               num:
+                 source: increment-1/out
+             out: [out]
+             run: to_int
+    """)
+
+
+def test_subworkflows_can_use_globals_in_right_scope() -> None:
+    """Produce a subworkflow that uses a global."""
+    my_param = param("num", typ=int)
+    result = increment(num=add_constants(num=increment(num=my_param)))
+    wkflw = construct(result, simplify_ids=True)
+    subworkflows = render(wkflw)
+    rendered = subworkflows["__root__"]
+    del subworkflows["__root__"]
+
+    assert len(subworkflows) == 1
+    assert isinstance(subworkflows, dict)
+    osubworkflows = sorted(list(subworkflows.items()))
+
+    assert rendered == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          CONSTANT:
+            default: 3
+            label: CONSTANT
+            type: int
+          num:
+            label: num
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: increment-1/out
+            type: int
+        steps:
+          increment-1:
+             in:
+               num:
+                 source: add_constants-1/out
+             out: [out]
+             run: increment
+          increment-2:
+             in:
+               num:
+                 source: num
+             out: [out]
+             run: increment
+          add_constants-1:
+             in:
+               CONSTANT:
+                 source: CONSTANT
+               num:
+                 source: increment-2/out
+             out: [out]
+             run: add_constants
+    """)
+
+    assert osubworkflows[0] == (
+        "add_constants-1",
+        yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          num:
+            label: num
+            type: int
+          CONSTANT:
+            default: 3
+            label: CONSTANT
+            type: int
+        outputs:
+          out:
+            label: out
+            outputSource: to_int-1-1/out
+            type: int
+        steps:
+          sum-1-1:
+            in:
+              left:
+                source: num
+              right:
+                source: CONSTANT
+            out:
+            - out
+            run: sum
+          sum-1-2:
+            in:
+              left:
+                source: sum-1-1/out
+              right:
+                source: CONSTANT
+            out:
+            - out
+            run: sum
+          to_int-1-1:
+            in:
+              num:
+                source: sum-1-2/out
+            out:
+            - out
+            run: to_int
+    """),
+    )
+
+
+@define
+class PackResult:
+    """A class representing the counts of card suits in a deck, including hearts, clubs, spades, and diamonds."""
+
+    hearts: int
+    clubs: int
+    spades: int
+    diamonds: int
+
+
+def test_combining_attrs_and_factories() -> None:
+    """Check combining attributes from a dataclass with factory-produced instances."""
+    Pack = factory(PackResult)
+
+    @task()
+    def sum(left: int, right: int) -> int:
+        return left + right
+
+    @workflow()
+    def black_total(pack: PackResult) -> int:
+        return sum(left=pack.spades, right=pack.clubs)
+
+    pack = Pack(hearts=13, spades=13, diamonds=13, clubs=13)
+    wkflw = construct(black_total(pack=pack), simplify_ids=True)
+    cwl = render(wkflw, allow_complex_types=True, factories_as_params=True)
+    assert cwl["__root__"] == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          PackResult-1:
+            label: PackResult-1
+            type: record
+        outputs:
+          out:
+            label: out
+            outputSource: black_total-1/out
+            type: int
+        steps:
+          black_total-1:
+            in:
+              pack:
+                source: PackResult-1/out
+            out:
+            - out
+            run: black_total
+    """)
+
+    assert cwl["black_total-1"] == yaml.safe_load("""
+        class: Workflow
+        cwlVersion: 1.2
+        inputs:
+          pack:
+            label: pack
+            type: record
+        outputs:
+          out:
+            label: out
+            outputSource: sum-1-1/out
+            type: int
+        steps:
+          sum-1-1:
+            in:
+              left:
+                source: pack/spades
+              right:
+                source: pack/clubs
+            out:
+            - out
+            run: sum
     """)


### PR DESCRIPTION
## Releasing 0.10.0

This PR is to release 0.10.0.

## Improvements

### Annotations

* add ability to annotate variables
* correct name to AtRender

### Inspection

* function inspection does not work right with python>=3.12.8 so pull forward better getclosurevars logic from dewret 0.11 channel and accept that the existing logic is too brittle

### Renderers

* add way to output subworkflows to files
* make the renderer semantics less janky
* can pick renderers dynamically

### Sympy

* more flexible parameter support
* handle arithmetic/structure manipulation of references
* support none in dicts

### Fields

* make it possible to use a plain dict if configured for fields
* can go upwards in fields

### Iterables

* allow spreading
* provide len for Fixed
* support list/tuple return values
* add loopable parameters

### Imports

* retrieve annotations from imported modules
* add a catch for a bug in the first import
* double-check importing correctly errors if render neither behaves as a package nor isolated module

### Positionals

* allow positional arguments if configuration override supplied

### Typing

* move @subworkflow to @workflow
* make types consistent in core

### Docs &amp; Linting

* ensure callback names unused parameter consistently for mypy
* dataclass field types now cause mypy errors
* ignore for ExprType
* updated renderer tutorial with the protocols implementation needed for a custom renderer to be considered a dewret renderer
* added docstrings to annotation tests
* allow subclassing any for mypy to enable subclassing Symbol
* fix tests and types for mypy and ruff on 3.11 and 3.12
* fix mypy issue in tests on 3.11
* fix up typehints and disable mypy sympy checking, as sympy does not have typehints

### Tests

* add test docstrings
* ensure pytest ignores tests._lib
* restore commented test
* restore 3.11 in test
* try 3.12 in test

### CI

* add 3.12 to the build matrix
* typo in workflow
* typo in workflow
* enable example tests in CI

### CWL

* deal with fact we cannot comprehensively type-check to_output_schema for CWL re. dataclass fields
* added a test for default renderer

### CLI

* add the ability to pass renderer arguments via CLI/YAML
* abstracted write_rendered_output from the main dewret CLI
* add construct args to CLI

## General Minor Fixes

* add configuration for simplify_ids
* add `is_firm`
* address field and hashing consistency
* allow fields of parameters
* allow workflows to come from packages
* better error message for iterating a non-iterable
* check that importing a non-compliant render module throws an error
* confirm tuples can be returned
* construct kwargs used to set_configuration
* correct logic for remapping before a workflow has a name
* correct name of default_config
* correctly handle flattened nested tasks
* do not lose the field structure when iterating
* efficiency improvements
* ensure that fieldability doesn't mean dask matches references as a Delayed
* expressions should consider Raw as a raw type
* fix explanatory text
* fix render load order
* fixups in iteration
* formating
* formatted methods
* ignore annotations when looking at fieldability
* integrate flatten_all_nested configuration
* is_raw_type should handle union types
* make __make_reference__ pass workflow if none
* make field separator configurable
* make result ordering consistent
* make sure the globals are updated when a subworkflow is running
* make sure we can identify an iterated ref
* move indexing to find_field
* nested raw is parseable
* reduce number of workflow merges
* refactored render.py:get_render_method for better readability, added explanitory comments
* remove Graph import from dask.typing in backend_dask as it seems to cause errors
* remove duplicate __hash__ method
* remove unnecessary abstractmethod annotation
* remove variable re-use
* render configuration
* replace all Unions with | for consistency
* resolve the parameter deduplication
* scope thread pools to a single render call and add context copying
* sorted should not break for two identical steps
* step reference works as tuple
* throw import exceptions
* tidy up 0.9.2 merge, mostly label corrections
* tidy up type parsing
* unbreak the doublequotes
