### PR TITLE
🐛 Set a constraint on Sympy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.11"
-dependencies = ["dask >= 2022", "pyyaml", "attrs", "click", "setuptools >= 65.5.1", "numpy", "sympy"]
+dependencies = ["dask >= 2022", "pyyaml", "attrs", "click", "setuptools >= 65.5.1", "numpy", "sympy < 1.14.0"]
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
## 🐛 Bug Fix

### Description

Fixing issue #88.
Sympy dependency update breaks tests.

### Root Cause:

When I updated my dependencies Sympy got updated to 1.14.0, which cause the following error in some tests:
![image](https://github.com/user-attachments/assets/7b4b59d7-8a8e-42eb-b581-8d2a596b6dbd)

### Testing:

Constrained the version to below 1.14.0. 
Ran all of the tests.

### Checklist

- [x] I have included a clear description of the bug.
- [x] I have listed the steps to reproduce the issue.
- [x] I have run the test suite and verified it passes.
- [x] I have attached any relevant logs or screenshots.

### Who can review?

@philtweir @edufnt @elleryames 